### PR TITLE
first cut mjd cutout storage

### DIFF
--- a/common/src/objectStore.py
+++ b/common/src/objectStore.py
@@ -1,5 +1,6 @@
 # A simple object store implemented on a file system
 # Roy Williams 2020
+# updated with primary directory as integer MJD
 
 import os
 import hashlib
@@ -8,7 +9,7 @@ class objectStore():
     """objectStore.
     """
 
-    def __init__(self, suffix='txt', fileroot='/data', double=False):
+    def __init__(self, suffix='txt', fileroot='/data'):
         """__init__.
 
         Args:
@@ -19,61 +20,61 @@ class objectStore():
         os.system('mkdir -p ' + fileroot)
         self.fileroot = fileroot
         self.suffix = suffix
-        self.double = double
     
-    def getFileName(self, objectId, mkdir=False):
+    def getFileName(self, objectId, imjd, mkdir=False):
         """getFileName.
 
         Args:
             objectId:
+            imjd:
             mkdir:
         """
+        imjddir = self.fileroot +'/' + '%d'%imjd + '/'
+        if mkdir:
+            try: os.makedirs(imjddir)
+            except: pass
+
         # hash the filename for the directory, use the last 3 digits
         # max number of directories 16**3 = 4096
         h = hashlib.md5(objectId.encode())
-        dir = h.hexdigest()[:3]
-        if self.double:
-            dir += '/' + h.hexdigest()[3:6]
-
+        imjddirhash = imjddir + h.hexdigest()[:3] + '/'
         if mkdir:
-            try:
-                os.makedirs(self.fileroot+'/'+dir)
-#                print('%s made %s' % (self.suffix, dir))
-            except:
-                pass
-        return self.fileroot +'/%s/%s.%s' % (dir, objectId, self.suffix)
+            try: os.makedirs(imjddirhash)
+            except: pass
 
-    def getFileObject(self, objectId):
+        return imjddirhash + objectId +'.' + self.suffix
+
+    def getFileObject(self, objectId, imjd):
         """getObject.
 
         Args:
             objectId:
         """
-        f = open(self.getFileName(objectId), 'rb')
+        f = open(self.getFileName(objectId, imjd), 'rb')
         return f
 
-    def getObject(self, objectId):
+    def getObject(self, objectId, imjd):
         """getObject.
 
         Args:
             objectId:
         """
         try:
-            f = open(self.getFileName(objectId))
+            f = open(self.getFileName(objectId, imjd))
             str = f.read()
             f.close()
             return str
         except:
             return None
 
-    def putObject(self, objectId, objectBlob):
+    def putObject(self, objectId, imjd, objectBlob):
         """putObject.
 
         Args:
             objectId:
             objectBlob:
         """
-        filename = self.getFileName(objectId, mkdir=True)
+        filename = self.getFileName(objectId, imjd, mkdir=True)
 #        print(objectId, filename)
         if isinstance(objectBlob, str):
             f = open(filename, 'w')
@@ -82,25 +83,10 @@ class objectStore():
         f.write(objectBlob)
         f.close()
 
-    def getObjects(self, objectIdList):
-        """getObjects.
-
-        Args:
-            objectIdList:
-        """
-        # get a bunch of objects from a bunch of identifiers
-        D = {}
-        for objectId in objectIdList:
-            s = self.getObject(objectId)
-            D[objectId] = json.loads(s)
-        return json.dumps(D, indent=2)
-
-    def putObjects(self, objectBlobDict):
-        """putObjects.
-
-        Args:
-            objectBlobDict:
-        """
-        # put a bunch of objects from a dict of objectId:object
-        for (objectId, objectBlob) in objectBlobDict.items():
-            self.putObject(objectId, objectBlob)
+if __name__ == '__main__':
+    ost = objectStore('txt', '/home/ubuntu/lasair-lsst/common/src/junk')
+    f = ost.getFileName('blabla456', 60000)
+    print(f)
+    ost.putObject('blabla456', 60000, 'lorem ipsum ...') 
+    c = ost.getObject('blabla456', 60000)
+    print(c)

--- a/pipeline/ingest/ingest.py
+++ b/pipeline/ingest/ingest.py
@@ -59,13 +59,13 @@ def msg_text(message):
                     if k not in ['cutoutDifference', 'cutoutTemplate', 'cutoutScience']}
     return message_text
 
-def store_images(message, store, diaSourceId):
+def store_images(message, store, diaSourceId, imjd):
     global log
     try:
         for cutoutType in ['cutoutDifference', 'cutoutTemplate']:
             content = message[cutoutType]
             filename = '%d_%s' % (diaSourceId, cutoutType)
-            store.putObject(filename, content)
+            store.putObject(filename, imjd, content)
         return True
     except Exception as e:
         log.error('ERROR in ingest/ingest: ', e)
@@ -126,9 +126,12 @@ def handle_alert(lsst_alert, image_store, producer, topic_out, cassandra_session
     # ID for the latest detection, this is what the cutouts belong to
     diaSourceId = lsst_alert_noimages['diaSource']['diaSourceId']
 
+    # MJD for storing images
+    imjd = int(lsst_alert_noimages['diaSource']['midPointTai'])
+
     # store the fits images
     if image_store:
-        if store_images(lsst_alert, image_store, diaSourceId) == None:
+        if store_images(lsst_alert, image_store, diaSourceId, imjd) == None:
             log.error('ERROR: in ingest/ingest: Failed to put cutouts in file system')
             return 0   # ingest batch failed
 

--- a/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
@@ -60,8 +60,8 @@
 			    <td>{{ cand.filtername }}</td>
 			    <td>{{ cand.psflux|floatformat:0 }} &plusmn; {{ cand.psfluxerr|floatformat:0 }}</td>
                             <td>
-                                {% if cand.image_urls.Template %} <a href='javascript:JS9Popout("/fits/{{ cand.diasourceid }}_cutoutTemplate");'><small>ref</small></a> {% endif %}
-                                {% if cand.image_urls.Difference %} <a href='javascript:JS9Popout("/fits/{{ cand.diasourceid }}_cutoutDifference");'><small>diff</small></a> {% endif %}
+				    {% if cand.image_urls.Template %} <a href='javascript:JS9Popout("/fits/{{cand.imjd}}/{{ cand.diasourceid }}_cutoutTemplate");'><small>ref</small></a> {% endif %}
+				    {% if cand.image_urls.Difference %} <a href='javascript:JS9Popout("/fits/{{cand.imjd}}/{{ cand.diasourceid }}_cutoutDifference");'><small>diff</small></a> {% endif %}
                             </td>
 
                             <td> <a tabindex="0" class="disable"  data-bs-html="true"  data-bs-container="body" data-bs-toggle="popover" data-bs-trigger="focus" data-bs-placement="top" data-bs-content='<pre><code>{{cand.json}}</code></pre>'>data</a></td>

--- a/webserver/lasair/templates/includes/widgets/widget_object_stamps.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_stamps.html
@@ -63,11 +63,11 @@
         <div class="row d-xl-flex align-items-centre">
             <div class="col-4">
                 <h2 class="h6 text-gray-400 mb-0">reference</h2>
-                <div class="fitsStamp fits-lite" src="/fits/{{ data.diaSources.0.diasourceid }}_cutoutTemplate"></div>
+		<div class="fitsStamp fits-lite" src="/fits/{{ data.diaSources.0.imjd }}/{{ data.diaSources.0.diasourceid }}_cutoutTemplate"></div>
             </div>
             <div class="col-4">
                 <h2 class="h6 text-gray-400 mb-0">difference</h2>
-                <div class="fitsStamp fits-lite" src="/fits/{{ data.diaSources.0.diasourceid }}_cutoutDifference"></div>
+		<div class="fitsStamp fits-lite" src="/fits/{{ data.diaSources.0.imjd }}/{{ data.diaSources.0.diasourceid }}_cutoutDifference"></div>
             </div>
         </div>
     </div>

--- a/webserver/lasair/urls.py
+++ b/webserver/lasair/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     path('privacy', TemplateView.as_view(template_name='privacy.html'), name='privacy'),
 
     path('admin/', admin.site.urls),
-    path('fits/<slug:candid_cutoutType>/', fits, name='fits'),
+    path('fits/<int:imjd>/<slug:candid_cutoutType>/', fits, name='fits'),
     path('', include('lasairapi.urls')),
     path('', include('lasair.apps.annotator.urls')),
     path('', include('lasair.apps.db_schema.urls')),

--- a/webserver/lasair/utils.py
+++ b/webserver/lasair/utils.py
@@ -202,6 +202,7 @@ def objjson(diaObjectId, full=False):
         json_formatted_str = json.dumps(diaSource, indent=2)
         diaSource['json'] = json_formatted_str[1:-1]
         diaSource['mjd'] = mjd = float(diaSource['midpointtai'])
+        diaSource['imjd'] = int(mjd)
         diaSource['since_now'] = mjd - now
         count_all_diaSources += 1
         diaSourceId = diaSource['diasourceid']
@@ -213,7 +214,7 @@ def objjson(diaObjectId, full=False):
         diaSource['image_urls'] = {}
         for cutoutType in ['Template', 'Difference']:
             diaSourceId_cutoutType = '%s_cutout%s' % (diaSourceId, cutoutType)
-            filename = image_store.getFileName(diaSourceId_cutoutType)
+            filename = image_store.getFileName(diaSourceId_cutoutType, int(mjd))
             if 1 == 1 or os.path.exists(filename):
                 url = filename.replace(
                     '/mnt/cephfs/lasair',
@@ -317,11 +318,11 @@ def string2bytes(str):
     return bytes
 
 
-def fits(request, candid_cutoutType):
+def fits(request, imjd, candid_cutoutType):
     # cutoutType can be cutoutDifference, cutoutTemplate, cutoutScience
     image_store = objectStore.objectStore(suffix='fits', fileroot=settings.IMAGEFITS)
     try:
-        fitsdata = image_store.getFileObject(candid_cutoutType)
+        fitsdata = image_store.getFileObject(candid_cutoutType, imjd)
     except:
         fitsdata = ''
 


### PR DESCRIPTION
How to modify the cutout storage system so that directories look like 
`http://lasair-lsst/fits/60070/181071543411933804_cutoutTemplate`
where the integer part of the MJD of the diaSource is in the URL and the file name

Modified:
objectStore in common/src
ingest.py in pipeline/ingest
urls.py in webserver so fits URL has iMJD
templates to generate correct fits call with iMJD
utils.py to compute iMJD for the templates
