### PR TITLE
Feature/cassandra schema

### DIFF
--- a/common/schema/convert.py
+++ b/common/schema/convert.py
@@ -72,7 +72,7 @@ def cql_create_table(schema):
         lines.append(s)
     #    if 'doc'     in f and f['doc']:     s += ', ' + f['doc']
     
-    cql = 'CREATE TABLE ' + schema['name'] + '(\n'
+    cql = 'CREATE TABLE IF NOT EXISTS ' + schema['name'] + '(\n'
     cql += ',\n'.join(lines)
 
     if 'indexes' in schema:

--- a/common/schema/lasair_cql/diaForcedSources.cql
+++ b/common/schema/lasair_cql/diaForcedSources.cql
@@ -1,4 +1,4 @@
-CREATE TABLE diaForcedSources(
+CREATE TABLE IF NOT EXISTS diaForcedSources(
 diaForcedSourceId bigint,
 ccdVisitId bigint,
 diaObjectId bigint,

--- a/common/schema/lasair_cql/diaNondetectionLimits.cql
+++ b/common/schema/lasair_cql/diaNondetectionLimits.cql
@@ -1,4 +1,4 @@
-CREATE TABLE diaNondetectionLimits(
+CREATE TABLE IF NOT EXISTS diaNondetectionLimits(
 ccdVisitId bigint,
 midPointTai double,
 filterName ascii,

--- a/common/schema/lasair_cql/diaObjects.cql
+++ b/common/schema/lasair_cql/diaObjects.cql
@@ -1,4 +1,4 @@
-CREATE TABLE diaObjects(
+CREATE TABLE IF NOT EXISTS diaObjects(
 diaObjectId bigint,
 ra double,
 decl double,

--- a/common/schema/lasair_cql/diaSources.cql
+++ b/common/schema/lasair_cql/diaSources.cql
@@ -1,4 +1,4 @@
-CREATE TABLE diaSources(
+CREATE TABLE IF NOT EXISTS diaSources(
 diaSourceId bigint,
 ccdVisitId bigint,
 diaObjectId bigint,

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -168,8 +168,9 @@
     - settings.yaml
   vars:
     cassandra_cluster_name: "{{ lasair_name }}"
+    git_branch: "{{ lasair_version }}"
   roles:
-    - gkansible.gkservercollection.cassandra_schema_lasair
+    - lasair_cassandra
   tags: cassandra
 
 - hosts: parallel_ssh

--- a/deploy/roles/lasair_cassandra/README.md
+++ b/deploy/roles/lasair_cassandra/README.md
@@ -1,0 +1,29 @@
+Role Name
+=========
+
+Role for initial setup of the Lasair cassandra keyspace and tables.
+
+Role Variables
+--------------
+
+`replication_factor`: Replication Factor (default = 3)
+`keyspace`: Cassandra keyspace (default `lasair`)
+`git_raw_url`: The Raw git URL. Default `https://raw.githubusercontent.com/lsst-uk/lasair-lsst`
+
+
+These values do not need to be overridden and the default values should suffice.
+
+Example Playbook
+----------------
+
+    # Apply to either standalone DB host or the first Galera backend
+    - hosts: cassandranodes[0]
+      roles:
+        - lasair_cassandra
+
+
+License
+-------
+
+Apache-2.0
+

--- a/deploy/roles/lasair_cassandra/README.md
+++ b/deploy/roles/lasair_cassandra/README.md
@@ -1,14 +1,15 @@
 Role Name
 =========
 
-Role for initial setup of the Lasair cassandra keyspace and tables.
+Role for initial setup of the Lasair cassandra keyspace and tables. Run on ONE CASSANDRA NODE ONLY.
 
 Role Variables
 --------------
 
 `replication_factor`: Replication Factor (default = 3)
 `keyspace`: Cassandra keyspace (default `lasair`)
-`git_raw_url`: The Raw git URL. Default `https://raw.githubusercontent.com/lsst-uk/lasair-lsst`
+`git_raw_url`: The Raw git URL (default `https://raw.githubusercontent.com/lsst-uk/lasair-lsst`)
+`branch`: The branch on github that contains the correct CQL schema files (default `main`)
 
 
 These values do not need to be overridden and the default values should suffice.

--- a/deploy/roles/lasair_cassandra/README.md
+++ b/deploy/roles/lasair_cassandra/README.md
@@ -9,7 +9,7 @@ Role Variables
 `replication_factor`: Replication Factor (default = 3)
 `keyspace`: Cassandra keyspace (default `lasair`)
 `git_raw_url`: The Raw git URL (default `https://raw.githubusercontent.com/lsst-uk/lasair-lsst`)
-`branch`: The branch on github that contains the correct CQL schema files (default `main`)
+`git_branch`: The branch on github that contains the correct CQL schema files (default `main`)
 
 
 These values do not need to be overridden and the default values should suffice.

--- a/deploy/roles/lasair_cassandra/defaults/main.yml
+++ b/deploy/roles/lasair_cassandra/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+
+replication_factor: 3
+keyspace: 'lasair'
+
+# url to get git repo content from
+git_raw_url: "https://raw.githubusercontent.com/lsst-uk/lasair-lsst"
+# git branch to use
+git_branch: main

--- a/deploy/roles/lasair_cassandra/tasks/main.yml
+++ b/deploy/roles/lasair_cassandra/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# To be executed on ONE CASSANDRA NODE ONLY. (Doesn't matter which one!)
+# Code can be executed as often as necessary. Does not need to be idempotent.
+
+- name: Create keyspace
+  command: "{{ item }}"
+  with_items:
+    - "cqlsh -e \"create keyspace if not exists {{ keyspace }} WITH replication = {'class':'SimpleStrategy', 'replication_factor': {{ replication_factor }} };\""
+
+- name: Create tables
+  command: "cqlsh -e 'use {{ keyspace }}; {{ lookup('url', git_raw_url + '/' + git_branch + item, split_lines=false) }};'"
+  with_items:
+    - "/common/schema/lasair_cql/diaForcedSources.cql"
+    - "/common/schema/lasair_cql/diaNondetectionLimits.cql"
+    - "/common/schema/lasair_cql/diaSources.cql"
+    - "/common/schema/lasair_cql/diaObjects.cql"
+
+- name: flush handlers
+  meta: flush_handlers


### PR DESCRIPTION
Added a lasair_cassandra role create the schema in place of the gkansible.gkservercollection.cassandra_schema_lasair one (see deploy.yaml).  The code runs shell commands rather than includes any special cassandra-specific galaxy modules, and must be run on ONE CASSANDRA NODE ONLY.

Note that the default git_branch variable (main) contains CQL syntax errors which are fixed in this branch.

The code is completely idempotent, since IF NOT EXISTS is also valid syntax in CQL.

No integration tests yet added, since this is dependent on setting up the Jenkins environment.