### PR TITLE
fixed query on create filter so it has the right schema

### DIFF
--- a/webserver/lasair/templates/includes/widgets/widget_filter_creation_form.html
+++ b/webserver/lasair/templates/includes/widgets/widget_filter_creation_form.html
@@ -62,7 +62,7 @@
                             {% include "includes/help_popover.html" with title="SELECT Help" position="right" content="In the SELECT box type a comma-separated list of column names you wish to appear in the filter results. To find the columns you need, search the <a target='_blank' href='/schema/'>Lasair Schema Browser</a> or just start typing and use the auto-complete function to find and input the column names.</br></br>If your query overflows the textbox, consider adding newlines to make the query more readable." %}
 
                             <div id="select_div" class="input-group">
-                                <textarea name="selected" class="prism-live language-sql fill prism-live-source" required="" id="id_selected" spellcheck="false">{{ form.selected.value|default_if_none:"objects.diaObjectId, objects.gPSFluxMean, objects.taimax as 'latest detection',  sherlock_classifications.classification as 'predicted classification' " }}</textarea>
+                                <textarea name="selected" class="prism-live language-sql fill prism-live-source" required="" id="id_selected" spellcheck="false">{{ form.selected.value|default_if_none:"objects.diaObjectId, objects.gPSFluxMean, objects.maxTai as 'latest detection',  sherlock_classifications.classification as 'predicted classification' " }}</textarea>
                             </div>
                         </div>
 
@@ -92,7 +92,7 @@
 
                             {% include "includes/help_popover.html" with title="WHERE Help" position="right" content="In the WHERE box, you can further filter results to return only sources you are interested in. Use the standard MySQL operators to write the criteria for your filter." %}
                             <div id="where_div" class="input-group">
-                                <textarea name="conditions" class="prism-live language-sql fill prism-live-source"  id="id_conditions" spellcheck="false">{{ form.conditions.value|default_if_none:"objects.ncand > 2" }}</textarea>
+                                <textarea name="conditions" class="prism-live language-sql fill prism-live-source"  id="id_conditions" spellcheck="false">{{ form.conditions.value|default_if_none:"objects.nSources > 2" }}</textarea>
 
                             </div>
                         </div>


### PR DESCRIPTION
This PR corrects the default query in the "create filter" webflow. Now the attributes are in the object schema so the filter will actually run.
