### PR TITLE
add utils to inspect topic config and make topic persist

### DIFF
--- a/utility/persistTopic.py
+++ b/utility/persistTopic.py
@@ -1,0 +1,30 @@
+"""
+Make a Kafka topic non-expiring.
+"""
+import argparse
+import json
+from confluent_kafka.admin import AdminClient, ConfigResource, ConfigEntry, RESOURCE_TOPIC
+from time import sleep
+
+def get_config(conf):
+    settings = {
+        'bootstrap.servers': conf['broker'],
+        }
+    config = {}
+    admin_client = AdminClient(settings)
+    config_dict = { 'retention.ms': '-1' } 
+    topic = ConfigResource(RESOURCE_TOPIC, conf['topic'], config_dict)
+    #topic.add_incremental_config(ConfigEntry('retention.ms', 1))
+    #future = admin_client.incremental_alter_configs([topic], validate_only=True)
+    result_dict = admin_client.alter_configs([topic])
+    result_dict[topic].result()
+    sleep(0.2)
+
+if __name__ == '__main__':
+    # parse cmd line arguments
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-b', '--broker', type=str, default='localhost:9092', help='address:port of Kafka broker(s)')
+    parser.add_argument('-t', '--topic', type=str, help='topic to change', required=True)
+    conf = vars(parser.parse_args())
+
+    get_config(conf)

--- a/utility/topicConfig.py
+++ b/utility/topicConfig.py
@@ -1,0 +1,29 @@
+"""
+Get the configuration parameters for a Kafka topic.
+"""
+import argparse
+import json
+from confluent_kafka.admin import AdminClient, ConfigResource, RESOURCE_TOPIC
+from time import sleep
+
+def get_config(conf):
+    settings = {
+        'bootstrap.servers': conf['broker'],
+        }
+    config = {}
+    admin_client = AdminClient(settings)
+    topic = ConfigResource(RESOURCE_TOPIC, conf['topic'])
+    result = admin_client.describe_configs([topic])[topic].result()
+    for k,v in result.items():
+        config[k] = v.value
+    print(json.dumps(config, indent=2))
+    sleep(0.2)
+
+if __name__ == '__main__':
+    # parse cmd line arguments
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-b', '--broker', type=str, default='localhost:9092', help='address:port of Kafka broker(s)')
+    parser.add_argument('-t', '--topic', type=str, help='topic to inspect', required=True)
+    conf = vars(parser.parse_args())
+
+    get_config(conf)


### PR DESCRIPTION

Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/2612264961/How+to+do+Pull+Request#STEP-3%3A-Issue-a-Pull-Request-on-Github

# CHANGES

- Created two new utilities to inspect configuration of a kafka topic and make it non-expiring
- Partly fixes #60 (but still need to document in POO)
- Draft documentation at https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/3262676993/Persistent+Topics+draft
