### PR TITLE
Bugfix/http security

### DIFF
--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -20,6 +20,8 @@
     db_host: "{{ (groups['db'] + groups['cluster_control'] + [''])[0] }}"
     db_port: "{% if groups['db'] %}3306{% else %}9001{% endif %}"
     replication_count: "{{ 1 if (groups['kafka']|length)<2 else 2 }}"
+    # HTTP Sctrict Transport Security - should be true for prod, probably not for dev
+    use_hsts: false 
   roles:
     - lasair_cephfs
     - lasair_service

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -122,6 +122,8 @@
     - settings.yaml
   vars:
     enable_letsencrypt: true
+    # HTTP Sctrict Transport Security - should be true for prod, probably not for dev
+    use_hsts: false 
   roles:
     - proxy
   tags: proxy

--- a/deploy/roles/grafana/templates/nginx-tls.conf
+++ b/deploy/roles/grafana/templates/nginx-tls.conf
@@ -23,6 +23,7 @@ server {
         {% if use_hsts %}
         add_header Strict-Transport-Security "max-age=2592000" always;
         {% endif %}
+        add_header X-Frame-Options SAMEORIGIN always;
 
         location / {
                 proxy_set_header Host $http_host;

--- a/deploy/roles/grafana/templates/nginx-tls.conf
+++ b/deploy/roles/grafana/templates/nginx-tls.conf
@@ -23,11 +23,11 @@ server {
         {% if use_hsts %}
         add_header Strict-Transport-Security "max-age=2592000" always;
         {% endif %}
-        add_header X-Frame-Options SAMEORIGIN always;
-        add_header X-Content-Type-Options nosniff;
 
         location / {
                 proxy_set_header Host $http_host;
+                proxy_set_header X-Frame-Options SAMEORIGIN always;
+                proxy_set_header X-Content-Type-Options nosniff;
                 proxy_pass http://localhost:3000/;
         }
 }

--- a/deploy/roles/grafana/templates/nginx-tls.conf
+++ b/deploy/roles/grafana/templates/nginx-tls.conf
@@ -26,7 +26,7 @@ server {
 
         location / {
                 proxy_set_header Host $http_host;
-                proxy_set_header X-Frame-Options SAMEORIGIN always;
+                proxy_set_header X-Frame-Options SAMEORIGIN;
                 proxy_set_header X-Content-Type-Options nosniff;
                 proxy_pass http://localhost:3000/;
         }

--- a/deploy/roles/grafana/templates/nginx-tls.conf
+++ b/deploy/roles/grafana/templates/nginx-tls.conf
@@ -24,6 +24,7 @@ server {
         add_header Strict-Transport-Security "max-age=2592000" always;
         {% endif %}
         add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Content-Type-Options nosniff;
 
         location / {
                 proxy_set_header Host $http_host;

--- a/deploy/roles/grafana/templates/nginx-tls.conf
+++ b/deploy/roles/grafana/templates/nginx-tls.conf
@@ -20,6 +20,10 @@ server {
         include /etc/letsencrypt/options-ssl-nginx.conf;
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+        {% if use_hsts %}
+        add_header Strict-Transport-Security "max-age=2592000" always;
+        {% endif %}
+
         location / {
                 proxy_set_header Host $http_host;
                 proxy_pass http://localhost:3000/;

--- a/deploy/roles/jenkins/templates/nginx.conf
+++ b/deploy/roles/jenkins/templates/nginx.conf
@@ -31,8 +31,6 @@ server {
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
   add_header Strict-Transport-Security "max-age=31536000" always;
-  add_header X-Frame-Options SAMEORIGIN always;
-  add_header X-Content-Type-Options nosniff;
 
   location / {
       #sendfile off;
@@ -60,6 +58,9 @@ server {
       proxy_buffering            off;
       proxy_request_buffering    off; # Required for HTTP CLI commands
       proxy_set_header Connection ""; # Clear for keepalive
+
+      proxy_set_header X-Frame-Options SAMEORIGIN;
+      proxy_set_header X-Content-Type-Options nosniff;
   }
 }
 

--- a/deploy/roles/jenkins/templates/nginx.conf
+++ b/deploy/roles/jenkins/templates/nginx.conf
@@ -31,6 +31,7 @@ server {
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
   add_header Strict-Transport-Security "max-age=31536000" always;
+  add_header X-Frame-Options SAMEORIGIN always;
 
   location / {
       #sendfile off;

--- a/deploy/roles/jenkins/templates/nginx.conf
+++ b/deploy/roles/jenkins/templates/nginx.conf
@@ -30,6 +30,8 @@ server {
   include /etc/letsencrypt/options-ssl-nginx.conf;
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+  add_header Strict-Transport-Security "max-age=31536000" always;
+
   location / {
       #sendfile off;
       proxy_pass         http://jenkins;

--- a/deploy/roles/jenkins/templates/nginx.conf
+++ b/deploy/roles/jenkins/templates/nginx.conf
@@ -32,6 +32,7 @@ server {
 
   add_header Strict-Transport-Security "max-age=31536000" always;
   add_header X-Frame-Options SAMEORIGIN always;
+  add_header X-Content-Type-Options nosniff;
 
   location / {
       #sendfile off;

--- a/deploy/roles/proxy/templates/nginx-tls.conf
+++ b/deploy/roles/proxy/templates/nginx-tls.conf
@@ -36,8 +36,6 @@ server {
         {% if use_hsts %}
         add_header Strict-Transport-Security "max-age=2592000" always;
         {% endif %}
-        add_header X-Frame-Options SAMEORIGIN always;
-        add_header X-Content-Type-Options nosniff;
 
 #####################################################################
 # In order to direct traffic to the status page, uncomment the
@@ -48,6 +46,8 @@ server {
 
         location / {
                 proxy_set_header Host $http_host;
+                proxy_set_header X-Frame-Options SAMEORIGIN always;
+                proxy_set_header X-Content-Type-Options nosniff;
                 proxy_pass http://localhost:8080/;
         }
 }

--- a/deploy/roles/proxy/templates/nginx-tls.conf
+++ b/deploy/roles/proxy/templates/nginx-tls.conf
@@ -11,6 +11,10 @@ server {
         ssl_certificate_key /etc/letsencrypt/live/{{ server_name }}/privkey.pem;
         include /etc/letsencrypt/options-ssl-nginx.conf;
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+        {% if use_hsts %}
+        add_header Strict-Transport-Security "max-age=2592000" always;
+        {% endif %}
 }
 
 server {
@@ -26,6 +30,10 @@ server {
         ssl_certificate_key /etc/letsencrypt/live/{{ server_name }}/privkey.pem;
         include /etc/letsencrypt/options-ssl-nginx.conf;
         ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+        {% if use_hsts %}
+        add_header Strict-Transport-Security "max-age=2592000" always;
+        {% endif %}
 
 #####################################################################
 # In order to direct traffic to the status page, uncomment the

--- a/deploy/roles/proxy/templates/nginx-tls.conf
+++ b/deploy/roles/proxy/templates/nginx-tls.conf
@@ -34,6 +34,7 @@ server {
         {% if use_hsts %}
         add_header Strict-Transport-Security "max-age=2592000" always;
         {% endif %}
+        add_header X-Frame-Options SAMEORIGIN always;
 
 #####################################################################
 # In order to direct traffic to the status page, uncomment the

--- a/deploy/roles/proxy/templates/nginx-tls.conf
+++ b/deploy/roles/proxy/templates/nginx-tls.conf
@@ -15,6 +15,8 @@ server {
         {% if use_hsts %}
         add_header Strict-Transport-Security "max-age=2592000" always;
         {% endif %}
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Content-Type-Options nosniff;
 }
 
 server {
@@ -35,6 +37,7 @@ server {
         add_header Strict-Transport-Security "max-age=2592000" always;
         {% endif %}
         add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-Content-Type-Options nosniff;
 
 #####################################################################
 # In order to direct traffic to the status page, uncomment the

--- a/deploy/roles/proxy/templates/nginx-tls.conf
+++ b/deploy/roles/proxy/templates/nginx-tls.conf
@@ -46,7 +46,7 @@ server {
 
         location / {
                 proxy_set_header Host $http_host;
-                proxy_set_header X-Frame-Options SAMEORIGIN always;
+                proxy_set_header X-Frame-Options SAMEORIGIN;
                 proxy_set_header X-Content-Type-Options nosniff;
                 proxy_pass http://localhost:8080/;
         }


### PR DESCRIPTION
Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/2612264961/How+to+do+Pull+Request#STEP-3%3A-Issue-a-Pull-Request-on-Github

# CHANGES
- X-Frame-Options and X-Content-Type-Options headers appear to already be set everywhere I looked, but added a directive to the proxy config to set them anywhere to be sure.
- Set HTTP Strict Transport Security in the proxy config for Jenkins
- Allow HSTS in the proxy config elsewhere to be set using an option (in deploy.yaml) since this should probably be set for production but not dev

Fixes #55 
