### PR TITLE
front page cache

### DIFF
--- a/deploy/roles/webserver/templates/settings.py.j2
+++ b/deploy/roles/webserver/templates/settings.py.j2
@@ -58,6 +58,9 @@ ACTIVE_EXPIRE = 180  # days fo expiry of active filter/watchlist/watchmap
 
 WATCHLIST_MAX            = 100000
 WATCHLIST_MAX_CROSSMATCH =  50000
+
+FRONT_PAGE_CACHE = LASAIR_ROOT + '/front_page_cache.json'
+FRONT_PAGE_STALE = 1800
 ################################################################
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)

--- a/webserver/lasair/apps/watchlist/urls.py
+++ b/webserver/lasair/apps/watchlist/urls.py
@@ -5,6 +5,6 @@ urlpatterns = [
     path('watchlists/', views.watchlist_index, name='watchlist_index'),
     path('watchlists/<int:wl_id>/', views.watchlist_detail, name='watchlist_detail'),
     path('watchlists/<int:wl_id>/cat/', views.watchlist_download, name='watchlist_download'),
-    path('watchlists/<int:wl_id>/delete/', views.watchlist_delete, name='watchlist_delete')
+    path('watchlists/<int:wl_id>/delete/', views.watchlist_delete, name='watchlist_delete'),
     path('watchlists/<int:wl_id>/<slug:action>/', views.watchlist_detail, name='watchlist_detail_run'),
 ]

--- a/webserver/lasair/views.py
+++ b/webserver/lasair/views.py
@@ -4,6 +4,7 @@ import time
 import math
 import string
 import json
+import os
 from django.contrib.auth import login, authenticate
 from django.contrib.auth.models import User
 import src.date_nid as date_nid
@@ -14,6 +15,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.template.context_processors import csrf
 from django.http import HttpResponseRedirect, HttpResponse
 from django.shortcuts import render, get_object_or_404, redirect
+from django.conf import settings as django_settings
 import settings
 from lasair.apps.db_schema.utils import get_schema, get_schema_dict, get_schema_for_query_selected
 from src import db_connect
@@ -33,18 +35,6 @@ def index(request):
     sherlock_classes = ['SN', 'NT', 'CV', 'AGN']
     base_colors = ['dc322f', '268bd2', '2aa198', 'b58900']
 
-    # query finds only mag<17 alerts with at least 2 in light curve, with age < 7
-#    query = """
-#    SELECT objects.diaObjectId,
-#       objects.ra, objects.decl,
-#       tainow()-objects.maxTai AS "last detected",
-#       sherlock_classifications.classification AS "predicted type"
-#    FROM objects, sherlock_classifications
-#    WHERE objects.diaObjectId=sherlock_classifications.diaObjectId
-#       AND objects.maxTai > tainow()-7
-#       AND objects.nSources > 1
-#       AND sherlock_classifications.classification in 
-#    """
     query = """
     SELECT objects.diaObjectId,
        objects.ra, objects.decl,
@@ -58,11 +48,34 @@ def index(request):
     S = ['"' + sherlock_class + '"' for sherlock_class in sherlock_classes]
     query += '(' + ','.join(S) + ')'
 
-    msl = db_connect.readonly()
-    cursor = msl.cursor(buffered=True, dictionary=True)
-    cursor.execute(query)
+#    FRONT_PAGE_CACHE = '/home/ubuntu/front_page_cache.json'
+#    FRONT_PAGE_STALE = 1800
 
-    table = cursor.fetchall()
+    table = None
+    try:
+        # if there is a young cache file, try to use it
+        age = time.time() - os.stat(django_settings.FRONT_PAGE_CACHE).st_mtime
+        if age < django_settings.FRONT_PAGE_STALE:
+            f = open(django_settings.FRONT_PAGE_CACHE, 'r')
+            table = json.loads(f.read())
+            f.close()
+    except:
+        pass
+
+    if table is None:
+        msl = db_connect.readonly()
+        cursor = msl.cursor(buffered=True, dictionary=True)
+        cursor.execute(query)
+
+        table = cursor.fetchall()
+        # try to write a cache file
+        try:
+            f = open(django_settings.FRONT_PAGE_CACHE, 'w')
+            f.write(json.dumps(table, indent=2))
+            f.close()
+        except:
+            pass
+
     # ADD SCHEMA
     schema = get_schema_dict("objects")
 


### PR DESCRIPTION
simple code to cache the query that drives the front page, and run the query only if the cache file can't be opened or is older than 30 minutes

Needs two new in the django settings.py

FRONT_PAGE_CACHE = '/home/ubuntu/front_page_cache.json'
FRONT_PAGE_STALE = 1800
