### PR TITLE
added index for crossmatch_tns

### DIFF
--- a/common/schema/lasair_schema/crossmatch_tns.py
+++ b/common/schema/lasair_schema/crossmatch_tns.py
@@ -105,6 +105,7 @@ schema = {
   "indexes": [
     "id int(10) unsigned NOT NULL AUTO_INCREMENT",
     "PRIMARY KEY (`id`)",
-    "KEY `idx_htm16` (`htm16`)"
+    "KEY `idx_htm16` (`htm16`)",
+    "KEY tns_name_idx (tns_name)"
   ]
 }

--- a/common/schema/lasair_sql/crossmatch_tns.sql
+++ b/common/schema/lasair_sql/crossmatch_tns.sql
@@ -20,5 +20,6 @@ CREATE TABLE IF NOT EXISTS crossmatch_tns(
 `lasairmodified_date` timestamp DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 id int(10) unsigned NOT NULL AUTO_INCREMENT,
 PRIMARY KEY (`id`),
-KEY `idx_htm16` (`htm16`)
+KEY `idx_htm16` (`htm16`),
+KEY tns_name_idx (tns_name)
 )


### PR DESCRIPTION
Modified the actual table:
`ALTER TABLE crossmatch_tns ADD INDEX tns_name_idx (tns_name)`

Then added `KEY tns_name_idx (tns_name)` to the schema .py and .sql
