### PR TITLE
Service runner exit codes

### DIFF
--- a/pipeline/ingest/ingest_runner.py
+++ b/pipeline/ingest/ingest_runner.py
@@ -19,9 +19,11 @@ Options:
     --nid=NID            ZTF night number to use (default today)
     --topic_out=TOUT     Kafka topic for output [default:ztf_sherlock]
 """
+import os
 import sys
 from docopt import docopt
-from multiprocessing import Process
+from multiprocessing import Process, Value, Array
+import signal
 
 from ingest import run_ingest
 
@@ -32,7 +34,7 @@ sys.path.append('../../common/src')
 import slack_webhook, lasairLogging
 
 
-def setup_proc(n, nprocess, args):
+def setup_proc(exit_code, pids, n, nprocess, args):
     # Set up the logger
     lasairLogging.basicConfig(
         filename=f"/home/ubuntu/logs/ingest-{n}.log",
@@ -47,7 +49,13 @@ def setup_proc(n, nprocess, args):
     except Exception as e:
         log.exception('Exception')
         log.critical('Unrecoverable error in ingest: ' + str(e))
-        sys.exit(1)
+        # set the exit code
+        exit_code.value = 1
+        # send a SIGTERM to all other processes
+        for pid in pids:
+            if pid != os.getpid() and pid > 0:
+                print("Sending SIGTERM to process", pid)
+                os.kill(pid, signal.SIGTERM)
 
 
 if __name__ == '__main__':
@@ -58,14 +66,19 @@ if __name__ == '__main__':
     nprocess = int(args['--nprocess'])
     print('ingest_runner with %d processes' % nprocess)
 
+    exit_code = Value('i', 0)
+    pids = Array('i', nprocess)
+
     # Start up the processes
     process_list = []
     for i in range(nprocess):
-        p = Process(target=setup_proc, args=(i+1, nprocess, args))
+        p = Process(target=setup_proc, args=(exit_code, pids, i+1, nprocess, args))
         process_list.append(p)
         p.start()
+        pids[i] = p.pid
 
     for p in process_list:
         p.join()
 
-    print('ingest_runner exiting')
+    print("ingest_runner exiting with exit code", exit_code.value)
+    sys.exit(exit_code.value)

--- a/tests/integration/common/src/test_manage_status.py
+++ b/tests/integration/common/src/test_manage_status.py
@@ -69,20 +69,20 @@ class CommonManageStatusTest(unittest.TestCase):
         status = ms.read(7)
         self.assertEqual(status, {})
 
-#    def test_multiprocessing(self):
-#        msl = mysql.connector.connect(**config)
-#        procs = []
-#        for iproc in range(nproc):
-#            proc = Process(target=func, args=(msl, iproc,))
-#            procs.append(proc)
-#            proc.start()
-#        for proc in procs:
-#            proc.join()
+    def test_multiprocessing(self):
+        msl = mysql.connector.connect(**config)
+        procs = []
+        for iproc in range(nproc):
+            proc = Process(target=func, args=(msl, iproc,))
+            procs.append(proc)
+            proc.start()
+        for proc in procs:
+            proc.join()
 
-#        ms = manage_status(msl, 'test_lasair_statistics')
-#        status = ms.read(nid)
+        ms = manage_status(msl, 'test_lasair_statistics')
+        status = ms.read(nid)
 #        print(status)
-#        self.assertTrue(status['count'] == nproc*niter)
+        self.assertTrue(status['count'] == nproc*niter)
 
     def test_timer(self):
         td = timer('mango')

--- a/tests/integration/common/src/test_manage_status.py
+++ b/tests/integration/common/src/test_manage_status.py
@@ -69,20 +69,20 @@ class CommonManageStatusTest(unittest.TestCase):
         status = ms.read(7)
         self.assertEqual(status, {})
 
-    def test_multiprocessing(self):
-        msl = mysql.connector.connect(**config)
-        procs = []
-        for iproc in range(nproc):
-            proc = Process(target=func, args=(msl, iproc,))
-            procs.append(proc)
-            proc.start()
-        for proc in procs:
-            proc.join()
+#    def test_multiprocessing(self):
+#        msl = mysql.connector.connect(**config)
+#        procs = []
+#        for iproc in range(nproc):
+#            proc = Process(target=func, args=(msl, iproc,))
+#            procs.append(proc)
+#            proc.start()
+#        for proc in procs:
+#            proc.join()
 
-        ms = manage_status(msl, 'test_lasair_statistics')
-        status = ms.read(nid)
+#        ms = manage_status(msl, 'test_lasair_statistics')
+#        status = ms.read(nid)
 #        print(status)
-        self.assertTrue(status['count'] == nproc*niter)
+#        self.assertTrue(status['count'] == nproc*niter)
 
     def test_timer(self):
         td = timer('mango')

--- a/tests/unit/pipeline/ingest/test_ingest_runner.py
+++ b/tests/unit/pipeline/ingest/test_ingest_runner.py
@@ -1,6 +1,7 @@
 """Unit tests for ingest runner
 """
 
+import os
 import unittest
 import unittest.mock
 from unittest.mock import patch
@@ -16,24 +17,28 @@ class RunnerTest(unittest.TestCase):
     def test_run_ingest(self, mock_logging, mock_ingester):
         """Test that run_ingest works"""
         mock_ingester.return_value.run.return_value = 3
-        ingest_runner.setup_proc(1, 1, {})
+        ingest_runner.setup_proc(None, [], 1, 1, {})
         mock_logging.getLogger.return_value.debug.assert_called_with('Ingested 3 alerts')
 
     @patch('ingest.Ingester')
     @patch('ingest_runner.lasairLogging')
-    def test_run_ingest_exception(self, mock_logging, mock_ingester):
+    @patch('ingest_runner.os.kill')
+    def test_run_ingest_exception(self, mock_kill, mock_logging, mock_ingester):
         """Test handling of exception on run"""
+        mock_exit_code = unittest.mock.MagicMock()
         mock_ingester.return_value.run.return_value = 3
         mock_ingester.return_value.run.side_effect = Exception('Test error')
-        # Check that sys.exit is called when an exception happens
-        with self.assertRaises(SystemExit) as cm:
-            ingest_runner.setup_proc(1, 1, {})
+        # pid needs to be anything except ours
+        pid = os.getpid() + 1
+        # Check that exit code is set when an exception happens
+        ingest_runner.setup_proc(mock_exit_code, [pid], 1, 1, {})
         # check that the exit code was not 0
-        self.assertNotEqual(cm.exception.code, 0)
-        # check the exception was the expected one
-        mock_logging.getLogger.return_value.exception.assert_called()
+        self.assertNotEqual(mock_exit_code.value, 0)
         # check the exception got logged
+        mock_logging.getLogger.return_value.exception.assert_called()
         mock_logging.getLogger.return_value.critical.assert_called_with('Unrecoverable error in ingest: Test error')
+        # check SIGTERM got sent
+        mock_kill.assert_called()
 
 
 if __name__ == '__main__':

--- a/tests/unit/pipeline/sherlock/test_sherlock_runner.py
+++ b/tests/unit/pipeline/sherlock/test_sherlock_runner.py
@@ -1,6 +1,7 @@
 """Unit tests for sherlock runner
 """
 
+import os
 import unittest
 import unittest.mock
 from unittest.mock import patch

--- a/tests/unit/pipeline/sherlock/test_sherlock_runner.py
+++ b/tests/unit/pipeline/sherlock/test_sherlock_runner.py
@@ -14,24 +14,28 @@ class RunnerTest(unittest.TestCase):
     @patch('sherlock_runner.lasairLogging')
     def test_run_wrapper(self, mock_logging, mock_wrapper):
         """Test that run works"""
-        sherlock_runner.setup_proc(1, 2, 'test_config.json')
+        sherlock_runner.setup_proc(None, [], 1, 2, 'test_config.json')
         mock_wrapper.run.assert_called_once()
         mock_logging.getLogger.return_value.info.assert_called_with('Starting sherlock runner process 1 of 2')
 
     @patch('sherlock_runner.wrapper')
     @patch('sherlock_runner.lasairLogging')
-    def test_run_wrapper_exception(self, mock_logging, mock_wrapper):
+    @patch('sherlock_runner.os.kill')
+    def test_run_wrapper_exception(self, mock_kill, mock_logging, mock_wrapper):
         """Test handling of exception on run"""
+        mock_exit_code = unittest.mock.MagicMock()
         mock_wrapper.run.side_effect = Exception('Test error')
-        # Check that sys.exit is called when an exception happens
-        with self.assertRaises(SystemExit) as cm:
-            sherlock_runner.setup_proc(1, 1, 'test_config.json')
+        # pid needs to be anything except ours
+        pid = os.getpid() + 1
+        # Check that exit code is set when an exception happens
+        sherlock_runner.setup_proc(mock_exit_code, [pid], 1, 1, 'test_config.json')
         # check that the exit code was not 0
-        self.assertNotEqual(cm.exception.code, 0)
-        # check the exception was the expected one
-        mock_logging.getLogger.return_value.exception.assert_called()
+        self.assertNotEqual(mock_exit_code.value, 0)
         # check the exception got logged
+        mock_logging.getLogger.return_value.exception.assert_called()
         mock_logging.getLogger.return_value.critical.assert_called_with('Unrecoverable error in sherlock: Test error')
+        # check SIGTERM got sent
+        mock_kill.assert_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/2612264961/How+to+do+Pull+Request#STEP-3%3A-Issue-a-Pull-Request-on-Github

# CHANGES

- Ensure that ingest/sherlock runner returns the correct exit code when an error happens in a child process
- If one child process crashes then send a sigterm to the others
