### PR TITLE
removed RSP portal panel

### DIFF
--- a/tests/integration/common/src/test_manage_status.py
+++ b/tests/integration/common/src/test_manage_status.py
@@ -23,6 +23,7 @@ deltaT = 1
 nid    = 7
 
 def func(msl, iproc):
+    msl = mysql.connector.connect(**config)
     ms = manage_status(msl, 'test_lasair_statistics')
     for i in range(niter):
         time.sleep(deltaT*random())
@@ -70,7 +71,7 @@ class CommonManageStatusTest(unittest.TestCase):
         self.assertEqual(status, {})
 
     def test_multiprocessing(self):
-        msl = mysql.connector.connect(**config)
+        msl = None
         procs = []
         for iproc in range(nproc):
             proc = Process(target=func, args=(msl, iproc,))
@@ -79,6 +80,7 @@ class CommonManageStatusTest(unittest.TestCase):
         for proc in procs:
             proc.join()
 
+        msl = mysql.connector.connect(**config)
         ms = manage_status(msl, 'test_lasair_statistics')
         status = ms.read(nid)
 #        print(status)

--- a/webserver/lasair/apps/object/templates/object/object_detail.html
+++ b/webserver/lasair/apps/object/templates/object/object_detail.html
@@ -36,12 +36,6 @@
                 {% include "includes/widgets/widget_object_sherlock.html" %}
             </div>
 
-            {% if user.is_authenticated %}
-            <div class="col-12 col-xl-6 mb-4">
-                {% include "includes/widgets/widget_object_rsp.html" %}
-            </div>
-            {% endif %}
-
             <div class="col-12 mb-4">
                 {% include "includes/widgets/widget_object_lightcurve.html" %}
             </div>


### PR DESCRIPTION
I have removed the RSP portal panel because there is corresponding dataset in the RSP, so it makes to sense right now.

However I make a [new issue](https://github.com/lsst-uk/lasair-lsst/issues/183) detailing how to put back the work Gareth has done.