### PR TITLE
Special display when a column name is "url"

### DIFF
--- a/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
@@ -79,6 +79,8 @@
 
                                 {% if key == "diaObjectId" %}
                                     <td><a href='{% url "object_detail" object.diaObjectId %}'>{{ object.diaObjectId }}</a></td>
+				{% elif key == "url" and object.url|length > 0 %}
+    				    <td><a href={{ object.url }}>url</a></td>
 
                                 {% elif key in 'decmean' %}
                                     <td>{{object|keyvalue:key|floatformat:6 }}</td>

--- a/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_objectlist_table.html
@@ -80,7 +80,7 @@
                                 {% if key == "diaObjectId" %}
                                     <td><a href='{% url "object_detail" object.diaObjectId %}'>{{ object.diaObjectId }}</a></td>
 				{% elif key == "url" and object.url|length > 0 %}
-    				    <td><a href={{ object.url }}>url</a></td>
+    				    <td><a href="{{ object.url }}">url</a></td>
 
                                 {% elif key in 'decmean' %}
                                     <td>{{object|keyvalue:key|floatformat:6 }}</td>


### PR DESCRIPTION
In tables of objects, the `objectId` column header is enhanced with a URL to the object page. This enhancement works on a column header called`url`, assuming it is a link and making that link clickable. In particular, this is useful for annotations that fill in the url field. The relevant part of the SELECT clause is then, for example:
`BBBobjects.url as url`
