### PR TITLE
Hotfix/feature group str type

### DIFF
--- a/pipeline/filter/features/FeatureGroup.py
+++ b/pipeline/filter/features/FeatureGroup.py
@@ -80,7 +80,5 @@ class FeatureGroup:
                     schema[name]['type'] = "float"
                 elif schema[name]['type'] == "long":
                     schema[name]['type'] = "int"
-                elif schema[name]['type'] == "string":
-                    schema[name]['type'] = "str"
         return schema
 

--- a/pipeline/filter/features/FeatureGroup.py
+++ b/pipeline/filter/features/FeatureGroup.py
@@ -80,5 +80,9 @@ class FeatureGroup:
                     schema[name]['type'] = "float"
                 elif schema[name]['type'] == "long":
                     schema[name]['type'] = "int"
+                elif schema[name]['type'] == "string":
+                    schema[name]['type'] = "str"
+                elif schema[name]['type'] == "timestamp":
+                    schema[name]['type'] = "float"
         return schema
 

--- a/pipeline/filter/features/FeatureGroup.py
+++ b/pipeline/filter/features/FeatureGroup.py
@@ -80,5 +80,7 @@ class FeatureGroup:
                     schema[name]['type'] = "float"
                 elif schema[name]['type'] == "long":
                     schema[name]['type'] = "int"
+                elif schema[name]['type'] == "string":
+                    schema[name]['type'] = "str"
         return schema
 

--- a/tests/unit/pipeline/filter/sample_alerts/99999999999_object.json
+++ b/tests/unit/pipeline/filter/sample_alerts/99999999999_object.json
@@ -44,7 +44,7 @@
   "BBBPeakFlux": null,
   "BBBPeakAbsMag": null,
   "BBBPeakMJD": null,
-  "ebv": 0.05528389662504196,
+  "ebv": 0.0,
   "glat": null,
   "jumpFromMean20": null,
   "latestPairMJD": null,

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -69,14 +69,9 @@ class FeatureTest(TestCase):
         if 'name' in feature:
           name = schema[feature]['name']
           type = schema[feature]['type']
-          #if type == 'string':
-          #    type = 'str'
-          #if name == 'timestamp':
-          #    continue
           # check name is in the feature set
           self.assertIn(name, output)
           # check that either the type is ok or that the output is None and allowed to be so 
-          #print('===', name, type, output[name])
           self.assertTrue(
             (isinstance(output[name], eval(type))) or
             (output[name] is None and schema[feature].get('extra') != 'NOT NULL')
@@ -87,6 +82,7 @@ class FeatureTest(TestCase):
           else:
             self.assertEqual(output[name], sample_output[name], msg=name)
         else:
+          print(feature)
           self.assertTrue(False)
 
   def test4_run_all(self):

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -66,26 +66,25 @@ class FeatureTest(TestCase):
       self.assertTrue(isinstance(output, dict))
       # check the output matches the schema
       for feature in schema:
-        if 'name' in feature:
-          name = schema[feature]['name']
-          type = schema[feature]['type']
-          if type == 'string':
-              type = 'str'
-          if name == 'timestamp':
-              continue
-          # check name is in the feature set
-          self.assertIn(name, output)
+        name = schema[feature]['name']
+        type = schema[feature]['type']
+        if type == 'string':
+            type = 'str'
+        if name == 'timestamp':
+            continue
+        # check name is in the feature set
+        self.assertIn(name, output)
+        #print('===', name, type, output[name])
         # check that either the type is ok or that the output is None and allowed to be so 
-          print('===', name, type, output[name])
-          self.assertTrue(
-            (isinstance(output[name], eval(type))) or
-            (output[name] is None and schema[feature].get('extra') != 'NOT NULL')
-            )
-          # check that the content is correct
-          if isinstance(output[name], float):
-            self.assertAlmostEqual(output[name], sample_output[name], msg=name)
-          else:
-            self.assertEqual(output[name], sample_output[name], msg=name)
+        self.assertTrue(
+          (isinstance(output[name], eval(type))) or
+          (output[name] is None and schema[feature].get('extra') != 'NOT NULL')
+          )
+        # check that the content is correct
+        if isinstance(output[name], float):
+          self.assertAlmostEqual(output[name], sample_output[name], msg=name)
+        else:
+          self.assertEqual(output[name], sample_output[name], msg=name)
 
   def test4_run_all(self):
     """Test the run_all method"""

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -69,14 +69,14 @@ class FeatureTest(TestCase):
         if 'name' in feature:
           name = schema[feature]['name']
           type = schema[feature]['type']
-          if type == 'string':
-              type = 'str'
-          if name == 'timestamp':
-              continue
+          #if type == 'string':
+          #    type = 'str'
+          #if name == 'timestamp':
+          #    continue
           # check name is in the feature set
           self.assertIn(name, output)
-        # check that either the type is ok or that the output is None and allowed to be so 
-          print('===', name, type, output[name])
+          # check that either the type is ok or that the output is None and allowed to be so 
+          #print('===', name, type, output[name])
           self.assertTrue(
             (isinstance(output[name], eval(type))) or
             (output[name] is None and schema[feature].get('extra') != 'NOT NULL')

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -66,24 +66,20 @@ class FeatureTest(TestCase):
       self.assertTrue(isinstance(output, dict))
       # check the output matches the schema
       for feature in schema:
-        if 'name' in feature:
-          name = schema[feature]['name']
-          type = schema[feature]['type']
-          # check name is in the feature set
-          self.assertIn(name, output)
-          # check that either the type is ok or that the output is None and allowed to be so 
-          self.assertTrue(
-            (isinstance(output[name], eval(type))) or
-            (output[name] is None and schema[feature].get('extra') != 'NOT NULL')
-            )
-          # check that the content is correct
-          if isinstance(output[name], float):
-            self.assertAlmostEqual(output[name], sample_output[name], msg=name)
-          else:
-            self.assertEqual(output[name], sample_output[name], msg=name)
+        name = schema[feature]['name']
+        type = schema[feature]['type']
+        # check name is in the feature set
+        self.assertIn(name, output)
+        # check that either the type is ok or that the output is None and allowed to be so 
+        self.assertTrue(
+          (isinstance(output[name], eval(type))) or
+          (output[name] is None and schema[feature].get('extra') != 'NOT NULL')
+          )
+        # check that the content is correct
+        if isinstance(output[name], float):
+          self.assertAlmostEqual(output[name], sample_output[name], msg=name)
         else:
-          print(schema)
-          self.assertTrue(False)
+          self.assertEqual(output[name], sample_output[name], msg=name)
 
   def test4_run_all(self):
     """Test the run_all method"""

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -66,25 +66,26 @@ class FeatureTest(TestCase):
       self.assertTrue(isinstance(output, dict))
       # check the output matches the schema
       for feature in schema:
-        name = schema[feature]['name']
-        type = schema[feature]['type']
-        if type == 'string':
-            type = 'str'
-        if name == 'timestamp':
-            continue
-        # check name is in the feature set
-        self.assertIn(name, output)
-        #print('===', name, type, output[name])
+        if 'name' in feature:
+          name = schema[feature]['name']
+          type = schema[feature]['type']
+          if type == 'string':
+              type = 'str'
+          if name == 'timestamp':
+              continue
+          # check name is in the feature set
+          self.assertIn(name, output)
         # check that either the type is ok or that the output is None and allowed to be so 
-        self.assertTrue(
-          (isinstance(output[name], eval(type))) or
-          (output[name] is None and schema[feature].get('extra') != 'NOT NULL')
-          )
-        # check that the content is correct
-        if isinstance(output[name], float):
-          self.assertAlmostEqual(output[name], sample_output[name], msg=name)
-        else:
-          self.assertEqual(output[name], sample_output[name], msg=name)
+          print('===', name, type, output[name])
+          self.assertTrue(
+            (isinstance(output[name], eval(type))) or
+            (output[name] is None and schema[feature].get('extra') != 'NOT NULL')
+            )
+          # check that the content is correct
+          if isinstance(output[name], float):
+            self.assertAlmostEqual(output[name], sample_output[name], msg=name)
+          else:
+            self.assertEqual(output[name], sample_output[name], msg=name)
 
   def test4_run_all(self):
     """Test the run_all method"""

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -86,6 +86,8 @@ class FeatureTest(TestCase):
             self.assertAlmostEqual(output[name], sample_output[name], msg=name)
           else:
             self.assertEqual(output[name], sample_output[name], msg=name)
+        else:
+          self.assertTrue(False)
 
   def test4_run_all(self):
     """Test the run_all method"""

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -82,7 +82,7 @@ class FeatureTest(TestCase):
           else:
             self.assertEqual(output[name], sample_output[name], msg=name)
         else:
-          print(feature)
+          print(schema)
           self.assertTrue(False)
 
   def test4_run_all(self):


### PR DESCRIPTION
Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/2612264961/How+to+do+Pull+Request#STEP-3%3A-Issue-a-Pull-Request-on-Github

# CHANGES

- Convert string and timestamp types in the schema to (the names of) appropriate python types in FeatureGroup class instead of hacking the test
- Re-enable the test that was only "passing" because it was effectively disabled
- Change the ebv value in the sample output to 0 because this feature is currently disabled

This is an interim fix. I think we should still do a proper refactoring as per #239, but that is a much bigger (and less urgent) task.
