### PR TITLE
Hotfix/misc issues

### DIFF
--- a/deploy/roles/webserver/templates/settings.py.j2
+++ b/deploy/roles/webserver/templates/settings.py.j2
@@ -139,6 +139,9 @@ REST_FRAMEWORK = {
 
     # for somebody with a token in the 'powerapi' group
     'POWER_THROTTLE_RATES'  : { 'user': '10000/hour', },
+
+    # less strict JSON encoding RDW April 2025
+    'STRICT_JSON': False,
 }
 
 ROOT_URLCONF = 'lasair.urls'

--- a/webserver/lasair/apps/object/views.py
+++ b/webserver/lasair/apps/object/views.py
@@ -38,7 +38,7 @@ def object_detail(request, diaObjectId):
     ]
     ```           
     """
-    data = objjson(diaObjectId, full=True)
+    data = objjson(diaObjectId, lite=True)
 
     # how to replace the real data with fake data
 #    with open('/home/ubuntu/fake.json', 'r') as f:

--- a/webserver/lasair/apps/search/utils.py
+++ b/webserver/lasair/apps/search/utils.py
@@ -22,14 +22,14 @@ def conesearch_impl(cone):
     hitlist = []
     d = readcone(cone)
 
-    if 'objectIds' in d:
-        data = {'cone': cone, 'hitlist': d['objectIds'],
+    if 'diaObjectIds' in d:
+        data = {'cone': cone, 'hitlist': d['diaObjectIds'],
                 'message': 'Found LSST object names'}
         return data
 
     if 'TNSname' in d:
         cursor = connection.cursor()
-        query = 'SELECT objectId FROM watchlist_hits WHERE wl_id=%d AND name="%s"'
+        query = 'SELECT diaObjectId FROM watchlist_hits WHERE wl_id=%d AND name="%s"'
         query = query % (settings.TNS_WATCHLIST_ID, d['TNSname'])
         cursor.execute(query)
         hits = cursor.fetchall()
@@ -47,8 +47,8 @@ def conesearch_impl(cone):
         dra = radius / (3600 * math.cos(dec * math.pi / 180))
         dde = radius / 3600
         cursor = connection.cursor()
-        query = 'SELECT objectId,ramean,decmean FROM objects WHERE ramean BETWEEN %f and %f AND decmean BETWEEN %f and %f' % (ra - dra, ra + dra, dec - dde, dec + dde)
-#        query = 'SELECT DISTINCT objectId FROM candidates WHERE ra BETWEEN %f and %f AND decl BETWEEN %f and %f' % (ra-dra, ra+dra, dec-dde, dec+dde)
+        query = 'SELECT diaObjectId,ra,decl FROM objects WHERE ra BETWEEN %f and %f AND decl BETWEEN %f and %f' % (ra - dra, ra + dra, dec - dde, dec + dde)
+#        query = 'SELECT DISTINCT diaObjectId FROM candidates WHERE ra BETWEEN %f and %f AND decl BETWEEN %f and %f' % (ra-dra, ra+dra, dec-dde, dec+dde)
         cursor.execute(query)
         hits = cursor.fetchall()
         for hit in hits:
@@ -94,7 +94,7 @@ def readcone(cone):
         if t[0:2] == '20':
             return {'TNSprefix': '', 'TNSname': t}
         if len(t) == 19:
-            return {'objectIds': tok}
+            return {'diaObjectIds': tok}
 
 # if odd number of tokens, must end with radius in arcsec
     radius = 5.0

--- a/webserver/lasair/apps/search/views.py
+++ b/webserver/lasair/apps/search/views.py
@@ -70,7 +70,7 @@ def do_search(
     query = query.strip()
     query = query.replace(",", " ")
 
-    objectName = re.compile(r'(^[a-zA-Z]\S*|^.*[a-zA-Z]$)', re.S)
+    objectName = re.compile(r'(^[a-zA-Z]\S*|^.*[a-zA-Z]$|^\d{17,22})', re.S)
     objectMatch = objectName.match(query)
 
     queries = []

--- a/webserver/lasair/apps/search/views.py
+++ b/webserver/lasair/apps/search/views.py
@@ -62,7 +62,7 @@ def do_search(
     ```
     """
 
-    objectColumns = 'o.objectId, o.ramean,o.decmean, o.rmag, o.gmag, tainow()-o.maxTai as "last detected (days ago)"'
+    objectColumns = 'o.diaObjectId, o.ra,o.decl, o.r_psfFlux, o.g_psfFlux, tainow()-o.lastDiaSourceMJD as "last detected (days ago)"'
 
     msl = db_connect.remote()
     cursor = msl.cursor(buffered=True, dictionary=True)
@@ -81,10 +81,10 @@ def do_search(
     if objectMatch:
         objectName = objectMatch.group()
 
-        queries.append(f"select {objectColumns} from objects o where o.objectId = '{objectName}'")
-        queries.append(f"SELECT {objectColumns} FROM objects o, crossmatch_tns t, watchlist_cones w, watchlist_hits h where w.wl_id = {settings.TNS_WATCHLIST_ID} and w.cone_id=h.cone_id and h.objectId=o.objectId and t.tns_name = w.name and (w.name = '{objectName.replace('AT','').replace('SN','').replace('KN','')}' or LOCATE('{objectName}' ,t.disc_int_name))")
-        # queries.append(f"SELECT {objectColumns} FROM objects o, watchlist_hits h where h.wl_id = {settings.TNS_WATCHLIST_ID} AND h.objectId=o.objectId AND h.name = '{objectName.replace('AT','').replace('SN','').replace('KN','')}' ")
-        queries.append(f"SELECT {objectColumns} FROM objects o, sherlock_classifications s where s.objectId=o.objectId and o.objectId = '{objectName}'")
+        queries.append(f"select {objectColumns} from objects o where o.diaObjectId = '{objectName}'")
+        queries.append(f"SELECT {objectColumns} FROM objects o, crossmatch_tns t, watchlist_cones w, watchlist_hits h where w.wl_id = {settings.TNS_WATCHLIST_ID} and w.cone_id=h.cone_id and h.diaObjectId=o.diaObjectId and t.tns_name = w.name and (w.name = '{objectName.replace('AT','').replace('SN','').replace('KN','')}' or LOCATE('{objectName}' ,t.disc_int_name))")
+        # queries.append(f"SELECT {objectColumns} FROM objects o, watchlist_hits h where h.wl_id = {settings.TNS_WATCHLIST_ID} AND h.diaObjectId=o.diaObjectId AND h.name = '{objectName.replace('AT','').replace('SN','').replace('KN','')}' ")
+        queries.append(f"SELECT {objectColumns} FROM objects o, sherlock_classifications s where s.diaObjectId=o.diaObjectId and o.diaObjectId = '{objectName}'")
 
         for q in queries:
             cursor.execute(q)
@@ -122,15 +122,15 @@ def do_search(
 
         # Is there an object within RADIUS arcsec of this object? - KWS - need to fix the gkhtm code!!
         message, matches = coneSearchHTM(ra, dec, radius, 'objects', queryType=QUICK, conn=connection, django=True, prefix='htm', suffix='')
-        objectIds = [o[1]['objectId'] for o in matches]
-        objectIds = "','".join(objectIds)
-        query = f"select {objectColumns} from objects o where o.objectId in ('{objectIds}')"
+        diaObjectIds = [o[1]['diaObjectId'] for o in matches]
+        diaObjectIds = "','".join(diaObjectIds)
+        query = f"select {objectColumns} from objects o where o.diaObjectId in ('{diaObjectIds}')"
         cursor.execute(query)
         results += cursor.fetchall()
 
     # MAKE UNIQUE
     try:
-        results = list({v['objectId']: v for v in results}.values())
+        results = list({v['diaObjectId']: v for v in results}.values())
     except:
         pass
 

--- a/webserver/lasair/apps/watchlist/views.py
+++ b/webserver/lasair/apps/watchlist/views.py
@@ -275,7 +275,8 @@ def watchlist_detail(request, wl_id, action=False):
     query_hit = f"""
 SELECT
 h.name as "Catalogue ID", h.arcsec as "separation (arcsec)",c.cone_id, 
-o.diaObjectId, o.ra,o.decl, o.rPSFlux, o.gPSFlux, tainow()-o.maxTai as "last detected (days ago)"
+o.diaObjectId, o.ra,o.decl, o.r_psfFlux, o.g_psfFlux, 
+tainow()-o.lastDiaSourceMJD as "last detected (days ago)"
 FROM watchlist_cones AS c, watchlist_hits as h, objects AS o
 WHERE c.cone_id=h.cone_id AND h.diaObjectId=o.diaObjectId AND
 c.wl_id={wl_id} limit 1000
@@ -366,7 +367,7 @@ def watchlist_download(request, wl_id):
     cursor.execute('SELECT name FROM watchlists WHERE wl_id=%d' % wl_id)
     name = cursor.fetchall()[0]["name"].replace(" ", "_") + "_watchlist_original.csv"
 
-    cursor.execute('SELECT ra, decl, name, radius FROM watchlist_cones WHERE wl_id=%d LIMIT 10000' % wl_id)
+    cursor.execute('SELECT ra, decl, name, radius FROM watchlist_cones WHERE wl_id=%d' % wl_id)
     cones = cursor.fetchall()
     content = []
     content[:] = [','.join(str(value) for value in c.values()) for c in cones]

--- a/webserver/lasair/query_builder.py
+++ b/webserver/lasair/query_builder.py
@@ -151,7 +151,8 @@ def build_query(select_expression, from_expression, where_condition):
     # This is a comma-separated list, of very restricted form
     # Implicitly includes 'objects', dont care if they includid it or not.
     # Can include 'sherlock_classifications' and 'tns_crossmatch' and 'annotations'
-    # Can include 'watchlists:nnn' and 'areas:nnn' where nnn is an integer.
+    # Can include 'watchlists:nnn' and 
+    # 'areas:nnn' or watchmaps:nnn where nnn is an integer.
     # Cannot have both watchlist and crossmatch_tns (the latter IS a watchlist)
 
     sherlock_classifications = False  # using sherlock_classifications
@@ -174,12 +175,12 @@ def build_query(select_expression, from_expression, where_condition):
             except:
                 raise QueryBuilderError('Error in FROM list, %s not of the form watchlist:nnn' % table)
 
-        if table.startswith('area:'):
+        if table.startswith('area:') or table.startswith('watchmap:'):
             w = table.split(':')
             try:
                 area_ids = w[1].split('&')
             except:
-                raise QueryBuilderError('Error in FROM list, %s not of the form area:nnn' % table)
+                raise QueryBuilderError('Error in FROM list, %s not of the form area:nnn or watchmap:nnn' % table)
 
         # multiple annotations comes in here from web as annotator:apple&pear
         # comes in from API/client as annotator:apple, annotator:pear

--- a/webserver/lasair/utils.py
+++ b/webserver/lasair/utils.py
@@ -119,7 +119,7 @@ def decsex(de):
         return '-%02d:%02d:%.3f' % (d, m, s)
 
 
-def objjson(diaObjectId, full=False):
+def objjson(diaObjectId, lite=False):
     """return all data for an object as a json object (`diaObjectId`,`objectData`,`diaSources`,`count_isdiffpos`,`count_all_diaSources`,`count_diaNonDetectionLimits`,`sherlock`,`TNS`, `annotations`)
 
     **Usage:**
@@ -133,7 +133,10 @@ def objjson(diaObjectId, full=False):
     message = ''
     msl = db_connect.readonly()
     cursor = msl.cursor(buffered=True, dictionary=True)
-    query = 'SELECT nSources, ra, decl, firstDiaSourceMJD as mjdmin, lastDiaSourceMJD as mjdmax '
+    if lite:
+        query = 'SELECT nSources, ra, decl, firstDiaSourceMJD, lastDiaSourceMJD '
+    else:
+        query = 'SELECT * '
     query += 'FROM objects WHERE diaObjectId = %s' % diaObjectId
     cursor.execute(query)
     for row in cursor:
@@ -144,11 +147,13 @@ def objjson(diaObjectId, full=False):
 
     now = mjd_now()
     if objectData:
-        if objectData and 'annotation' in objectData and objectData['annotation']:
-            objectData['annotation'] = objectData['annotation'].replace('"', '').strip()
+#        if objectData and 'annotation' in objectData and objectData['annotation']:
+#            objectData['annotation'] = objectData['annotation'].replace('"', '').strip()
 
         objectData['rasex'] = rasex(objectData['ra'])
         objectData['decsex'] = decsex(objectData['decl'])
+        objectData['mjdmin'] = objectData['firstDiaSourceMJD']
+        objectData['mjdmax'] = objectData['lastDiaSourceMJD']
 
         (ec_lon, ec_lat) = ecliptic(objectData['ra'], objectData['decl'])
         objectData['ec_lon'] = ec_lon
@@ -190,7 +195,10 @@ def objjson(diaObjectId, full=False):
                 TNS[k] = v
 
     LF = lightcurve_fetcher(cassandra_hosts=lasair_settings.CASSANDRA_HEAD)
-    (diaSources, diaForcedSources) = LF.fetch(diaObjectId, full=full)
+    if lite:
+        (diaSources, diaForcedSources) = LF.fetch(diaObjectId, lite=lite)
+    else:
+        (diaObject, diaSources, diaForcedSources) = LF.fetch(diaObjectId, lite=lite)
     LF.close()
 
     count_all_diaSources = len(diaSources)
@@ -219,13 +227,13 @@ def objjson(diaObjectId, full=False):
     if count_all_diaSources == 0:
         return None
 
-    if not objectData:
-        ra = float(diaSource['ra'])
-        dec = float(diaSource['decl'])
-        objectData = {'ramean': ra, 'decmean': dec,
-                      'rasex': rasex(ra), 'decsex': decsex(dec),
-                      'ncand': len(diaSources), 'MPCname': ssnamenr}
-        objectData['annotation'] = 'Unknown object'
+#    if not objectData:
+#        ra = float(diaSource['ra'])
+#        dec = float(diaSource['decl'])
+#        objectData = {'ramean': ra, 'decmean': dec,
+#                      'rasex': rasex(ra), 'decsex': decsex(dec),
+#                      'ncand': len(diaSources), 'MPCname': ssnamenr}
+#        objectData['annotation'] = 'Unknown object'
 
     message += 'Got %d diaSources' % count_all_diaSources
 


### PR DESCRIPTION
- Fixed a number of inconsistencies in the "Search" app at the top of each web page.
- Corrected the object detection table for LSST schema. 
- Removed trailing comma from SELECT clause.
- [Area and watchmap](https://github.com/lsst-uk/lasair-lsst/issues/146)
- [Download whole watchlist](https://github.com/lsst-uk/lasair-lsst/issues/176)
- [Object/lightcurve fetching](https://github.com/lsst-uk/lasair-lsst/issues/221)

For the last one:
In each of the four cases the return will be a dictionary with diaObjectId and a combination of these 5 fields:
  diaObject, diaSources, diaForcedSources, imageUrls, lasairData

If the "lite" flag is True, then each diaSource and diaForcedSource is stripped to just the mjd/band/flux/fluxerr, and there is no diaObject. (cost=2 Cassandra queries)

If the "lite" flag is False, all attributes will be returned from diaSources, diaForcedSources, image_urls, and the full diaObject as from Rubin. (cost=3 Cassandra queries)

If the "lasair_added" flag is chosen, there will be a lasairData section with sherlock/TNS/annotations, and there will be a "objectData" section (cost=4 MySQL queries):
- If lite=True, the objectData section will be a few selected attributes from the diaObject (nsource/ra/dec/firstMJD/lastMJD).
- If lite=False, the lasair section will be all the added Lasair features, core attributes, and extended attributes.

The four ways to call the `object` method are shown in an [example notebook](https://github.com/lsst-uk/lasair-examples/blob/main/notebooks/ObjectAPI.ipynb)
