### PR TITLE
Fix/registration

### DIFF
--- a/deploy/common/settings.py.j2
+++ b/deploy/common/settings.py.j2
@@ -113,6 +113,9 @@ ANNOTATION_GROUP_ID    = 'test004'
 # Can have different web look and feel for different clusters
 WEB_DOMAIN             = '{{ lasair_name }}'
 
+# Make the register and passwordchange secure
+HASH_SALT              = '{{ hash_salt }}'
+
 # To include links in emails of filter results
 #LASAIR_URL             = 'lasair-iris.roe.ac.uk'
 LASAIR_URL             = '{{ lasair_name }}.{{ domain }}'

--- a/deploy/roles/webserver/templates/settings.py.j2
+++ b/deploy/roles/webserver/templates/settings.py.j2
@@ -192,6 +192,10 @@ DATABASES = {
 LOGIN_REDIRECT_URL = 'index'
 LOGIN_URL = 'login'
 
+AUTHENTICATION_BACKENDS = [
+    "django.contrib.auth.backends.AllowAllUsersModelBackend"
+]
+
 AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',

--- a/webserver/users/templates/users/activation_code.html
+++ b/webserver/users/templates/users/activation_code.html
@@ -23,13 +23,13 @@
 
 
                         <form method="post" action="/activate/" class="mt-4">
-				<input type="hidden" name="code" value="{{ code }}">
+				<input type="hidden" name="hashcode" value="{{ hashcode }}">
 				<input type="hidden" name="email" value="{{ email }}">
 
                             {% csrf_token %}
 
-			    An activation code has been sent to {{ email }}. 
-			    {{ message }}:
+			    An activation code has been sent to {{ email }}. Please type it here.
+			    {{ message }}
 
                             <div class="form-group mb-4">
                                 <label for="first_name">Activation Code</label>

--- a/webserver/users/templates/users/activation_code.html
+++ b/webserver/users/templates/users/activation_code.html
@@ -28,7 +28,8 @@
 
                             {% csrf_token %}
 
-			    An activation code has been sent to {{ email }}. Please enter it here:
+			    An activation code has been sent to {{ email }}. 
+			    {{ message }}:
 
                             <div class="form-group mb-4">
                                 <label for="first_name">Activation Code</label>

--- a/webserver/users/templates/users/activation_code.html
+++ b/webserver/users/templates/users/activation_code.html
@@ -1,0 +1,52 @@
+{% extends "layouts/base-fullscreen.html" %}
+{% load widget_tweaks %}
+{% block title %} Activation code {% endblock %}
+
+<!-- Specific Page CSS goes HERE  -->
+{% block stylesheets %}{% endblock stylesheets %}
+
+{% block content %}
+
+
+    <div class="container">
+        <div class="row justify-content-center">
+
+            <div class="col-12 d-flex align-items-center justify-content-center">
+
+                <div class="bg-white shadow border-0 rounded border-light p-4 p-lg-5 w-100 fmxw-500 mt-9">
+                    {% include "includes/icons/icon.html" %}
+                    <div class="text-center text-md-center mb-4 mt-md-0">
+                        <h1 class="mb-0 h3">
+                            Account Activation
+                        </h1>
+                    </div>
+
+
+                        <form method="post" action="/activate/" class="mt-4">
+				<input type="hidden" name="code" value="{{ code }}">
+				<input type="hidden" name="email" value="{{ email }}">
+
+                            {% csrf_token %}
+
+			    An activation code has been sent to {{ email }}. Please enter it here:
+
+                            <div class="form-group mb-4">
+                                <label for="first_name">Activation Code</label>
+                                <div class="input-group">
+                                    <input type="text" id="input_code" name="input_code"><br><br>
+                                </div>
+                            </div>
+
+                            <div class="d-grid mt-3">
+                                <button type="submit" name="activate" class="btn btn-gray-800">Activate</button>
+                            </div>
+                        </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+{% endblock content %}
+
+<!-- Specific Page JS goes HERE  -->
+{% block javascripts %}{% endblock javascripts %}

--- a/webserver/users/templates/users/email_verification_email.html
+++ b/webserver/users/templates/users/email_verification_email.html
@@ -1,9 +1,5 @@
 {% load i18n %}{% autoescape off %}
-{% blocktranslate %}Hi {{ user }},
-
-Please click on the link below to verify your email address and active your Lasair account:{% endblocktranslate %}
-
-https://{{ domain }}{% url 'activate' uidb64=uid token=token %}
-
-{% blocktranslate %}The Lasair team{% endblocktranslate %}
+Hi {{ user }},
+Please enter the following activation code:{{ code }}
+The Lasair team
 {% endautoescape %}

--- a/webserver/users/templates/users/login.html
+++ b/webserver/users/templates/users/login.html
@@ -63,7 +63,7 @@
                                         Remember me
                                     </label>
                                 </div>
-                                <div><a href="{% url 'password_reset' %}" class="small text-right">Lost password?</a></div>
+                                <div><a href="/password_reset/" class="small text-right">Lost password?</a></div>
                             </div>
                         </div>
                         <div class="d-grid">

--- a/webserver/users/templates/users/login.html
+++ b/webserver/users/templates/users/login.html
@@ -63,7 +63,7 @@
                                         Remember me
                                     </label>
                                 </div>
-                                <div><a href="/password_reset/" class="small text-right">Lost password?</a></div>
+                                <div><a href="/password_reset/" class="small text-right">Lost password? Inactive account?</a></div>
                             </div>
                         </div>
                         <div class="d-grid">

--- a/webserver/users/templates/users/password_reset_confirm.html
+++ b/webserver/users/templates/users/password_reset_confirm.html
@@ -20,11 +20,12 @@
                     <h1 class="h3 mb-4">Reset password</h1>
                     <form method="post">
                         {% csrf_token %}
-                        <input type="hidden" name="code" value="{{ code }}">
+                        <input type="hidden" name="hashcode" value="{{ hashcode }}">
                         <input type="hidden" name="email" value="{{ email }}">
                         <!-- Form -->
                         <div class="form-group mb-4">
-				Type here the activation code:
+				An email has been sent with the activation code.
+				Type it here:
                                 <input "text" class="form-control" name="input_code" required>
                             <label for="password">Your Password</label>
                             <div class="input-group">

--- a/webserver/users/templates/users/password_reset_confirm.html
+++ b/webserver/users/templates/users/password_reset_confirm.html
@@ -20,9 +20,12 @@
                     <h1 class="h3 mb-4">Reset password</h1>
                     <form method="post">
                         {% csrf_token %}
-
+                        <input type="hidden" name="code" value="{{ code }}">
+                        <input type="hidden" name="email" value="{{ email }}">
                         <!-- Form -->
                         <div class="form-group mb-4">
+				Type here the activation code:
+                                <input "text" class="form-control" name="input_code" required>
                             <label for="password">Your Password</label>
                             <div class="input-group">
                                 <span class="input-group-text" id="basic-addon2">

--- a/webserver/users/templates/users/password_reset_email.html
+++ b/webserver/users/templates/users/password_reset_email.html
@@ -1,12 +1,4 @@
 {% load i18n %}{% autoescape off %}
-    {% blocktranslate %}You're receiving this email because you requested to set/reset the password for your user account at {{ site_name }}.{% endblocktranslate %}
-
-    {% translate "Please go to the following page and choose a new password:" %}
-    {% block reset_link %}
-        https://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
-    {% endblock %}
-    {% translate 'Your username, in case you’ve forgotten, is' %} {{ user.get_username }}
-
-    {% blocktranslate %}The Lasair team{% endblocktranslate %}
-
+    You're receiving this email because you requested to set/reset the password for your Lasair user account.
+    Your activation code is {{ code }}.
 {% endautoescape %}

--- a/webserver/users/templates/users/password_reset_email.html
+++ b/webserver/users/templates/users/password_reset_email.html
@@ -1,4 +1,5 @@
 {% load i18n %}{% autoescape off %}
-    You're receiving this email because you requested to set/reset the password for your Lasair user account.
-    Your activation code is {{ code }}.
+You are receiving this email because you requested to set/reset the password for your Lasair user account with username {{ username }}.
+
+Your activation code is {{ code }}.
 {% endautoescape %}

--- a/webserver/users/urls.py
+++ b/webserver/users/urls.py
@@ -8,14 +8,10 @@ from django.conf import settings
 urlpatterns = [
     path('register/', views.register, name='register'),
     path('activate/', views.activate, name='activate'),
-    path('profile/', views.profile, name='profile'),
+    path('profile/',  views.profile,  name='profile'),
     path('login/', auth_views.LoginView.as_view(template_name="users/login.html"), name='login'),
-    path('logout/', views.logout, name='logout'),
-    path('password-reset-confirm/<uidb64>/<token>/', auth_views.PasswordResetConfirmView.as_view(template_name="users/password_reset_confirm.html", post_reset_login=True, success_url="/password-reset/success/"), name='password_reset_confirm'),
-    path('password-reset/success/', auth_views.PasswordResetDoneView.as_view(template_name="index.html", extra_context={"alert": "You have successfully changed your password and are now logged in."}), name='password_reset_success'),
-    path('password-reset/', auth_views.PasswordResetView.as_view(template_name="users/password_reset.html", email_template_name="users/password_reset_email.html"), name='password_reset'),
-    path('password-reset/done/', auth_views.PasswordResetDoneView.as_view(template_name="index.html", extra_context={"alert": "If your email is associated with a registered account, you will receive an email with instructions on how to change your password."}), name='password_reset_done'),
-    path('activate/<uidb64>/<token>', views.activate, name='activate')
+    path('logout/',   views.logout,   name='logout'),
+    path('password_reset/', views.password_reset,  name='password_reset'),
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/webserver/users/urls.py
+++ b/webserver/users/urls.py
@@ -6,7 +6,8 @@ from django.conf.urls.static import static
 from django.conf import settings
 
 urlpatterns = [
-    path('register/', views.register, name='register'),  # FIX ME
+    path('register/', views.register, name='register'),
+    path('activate/', views.activate, name='activate'),
     path('profile/', views.profile, name='profile'),
     path('login/', auth_views.LoginView.as_view(template_name="users/login.html"), name='login'),
     path('logout/', views.logout, name='logout'),

--- a/webserver/users/views.py
+++ b/webserver/users/views.py
@@ -9,6 +9,7 @@ from .forms import UserRegisterForm, ProfileUpdateForm, UserUpdateForm
 from django.contrib.auth.decorators import login_required
 import sys
 import hashlib
+import settings
 #from .utils import account_activation_token
 from django.template.loader import render_to_string
 #from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
@@ -16,7 +17,8 @@ from django.template.loader import render_to_string
 from django.core.mail import EmailMessage
 
 def get_hash(s):
-    encoded_string = s.encode()
+    salted_string = s + settings.HASH_SALT
+    encoded_string = salted_string.encode()
     sha1_hash = hashlib.sha1(encoded_string)
     return sha1_hash.hexdigest()
 

--- a/webserver/users/views.py
+++ b/webserver/users/views.py
@@ -58,6 +58,8 @@ def password_reset(request):
 
             if str(get_hash(input_code)) == hashcode:
                 user.set_password(new_password)
+                user.is_active = True
+                user.save()
                 messages.success(request, "Your password is changed. Now you can login to your account.")
                 return redirect('login')
             else:

--- a/webserver/users/views.py
+++ b/webserver/users/views.py
@@ -1,3 +1,4 @@
+import random
 from django.contrib.auth import logout as auth_logout
 from django.contrib.auth import authenticate, get_user_model
 from django.shortcuts import render, redirect
@@ -21,48 +22,48 @@ def register(request):
             user = form.save(commit=False)
             user.is_active = False
             user.save()
-            activateEmail(request, user, form.cleaned_data.get('email'))
-            return redirect('index')
+            code = '%06d' % random.randrange(999999)
+            email_address = form.cleaned_data.get('email')
+            mail_subject = "Activate your Lasair account."
+            message = render_to_string("users/email_verification_email.html", {
+                'email': email_address,
+                'code': code,
+            })
+            email = EmailMessage(mail_subject, message, to=[email_address])
+            if not email.send():
+                messages.error(request, 
+                f'Problem sending email to {email_address}, please check you typed it correctly.')
+
+            return render(request, 'users/activation_code.html', {'email': email_address, 'code':code})
+        else:
+            messages.error(request, "Form is not valid")
     else:
         form = UserRegisterForm()
-    return render(request, 'users/register.html', {'form': form})
+        return render(request, 'users/register.html', {'form': form})
 
 
-def activate(request, uidb64, token):
+def activate(request):
+    code       = request.POST.get("code")
+    input_code = request.POST.get("input_code")
+    email      = request.POST.get("email")
+
     User = get_user_model()
     try:
-        uid = force_str(urlsafe_base64_decode(uidb64))
-        user = User.objects.get(pk=uid)
+        users = User.objects.filter(email=email)
+        user = users[0]
     except:
         user = None
 
-    if user is not None and account_activation_token.check_token(user, token):
+    if user is not None and input_code == code:
         user.is_active = True
         user.save()
 
-        messages.success(request, "Thank you for verifying your email. Now you can login to your account.")
+        messages.success(request, "Thank you for verifying the activation code. Now you can login to your account.")
         return redirect('login')
     else:
-        messages.error(request, "Activation link is invalid!")
+        messages.error(request, "Activation code is invalid!")
 
     return redirect('index')
-
-
-def activateEmail(request, user, to_email):
-    mail_subject = "Activate your Lasair account."
-    message = render_to_string("users/email_verification_email.html", {
-        'user': user.username,
-        'domain': get_current_site(request).domain,
-        'uid': urlsafe_base64_encode(force_bytes(user.pk)),
-        'token': account_activation_token.make_token(user),
-        "protocol": 'https' if request.is_secure() else 'http'
-    })
-    email = EmailMessage(mail_subject, message, to=[to_email])
-    if email.send():
-        messages.success(request, f'We have sent you an email to {to_email}. Please follow the instructions to acivate your Lasair account. Can\'t find the email? Please check your spam folder.')
-    else:
-        messages.error(request, f'Problem sending email to {to_email}, please check you typed it correctly.')
-
 
 @login_required
 def profile(request):


### PR DESCRIPTION
Changed the registration and change-password workflow to send an activation code by email to the user, rather than a link. The problem is that the link gets twisted up by the user's mail client and often doesn't work as planned.
