### PR TITLE
Feature/sherlock cache expiry

### DIFF
--- a/deploy/roles/sherlock/tasks/database.yml
+++ b/deploy/roles/sherlock/tasks/database.yml
@@ -10,7 +10,13 @@
 - name: Create cache table
   community.mysql.mysql_query:
     query:
-      - "CREATE TABLE IF NOT EXISTS {{ cache_db }}.cache(`name` bigint PRIMARY KEY, `version` varchar(80), `class` varchar(16), `description` text, `crossmatch` text)"
+      - "CREATE TABLE IF NOT EXISTS {{ cache_db }}.cache(
+        `name` bigint PRIMARY KEY,
+        `version` varchar(80),
+        `class` varchar(16),
+        `description` text,
+        `crossmatch` text,
+        `updated` timestamp DEFAULT current_timestamp() ON UPDATE current_timestamp())"
       - "GRANT ALL PRIVILEGES ON cache.* TO '{{ sherlock_user }}'@'%'"
     login_host: 127.0.0.1
     login_user: root

--- a/deploy/roles/sherlock/tasks/wrapper.yml
+++ b/deploy/roles/sherlock/tasks/wrapper.yml
@@ -59,3 +59,24 @@
     #enabled: false
     name: lasair-sherlock
 
+- name: "Check the cron daemon is installed"
+  become: true
+  apt:
+    name:  cron
+    state: present
+
+- name: "Check the cron daemon is enabled and started"
+  become: true
+  service:
+    enabled: true
+    name:  cron
+    state: started
+
+# Set to expire based only on version number - can be changed to something more useful later
+- name: "Crontab for cache expiry"
+  cron:
+    name:   "Expire cache"
+    user:   "{{ ansible_env.USER }}"
+    minute: '40'
+    hour:   '22'
+    job:    "{{ ansible_env.HOME }}/{{ git_name }}/pipeline/sherlock/expire_cache.py --database mariadb://{{ sherlock_secret.user }}:{{ sherlock_secret.password }}@127.0.0.1/{{ cache_db }} --min_version=2.3.0"

--- a/pipeline/sherlock/expire_cache.py
+++ b/pipeline/sherlock/expire_cache.py
@@ -47,8 +47,7 @@ def main(args):
         elif args.get('--max_days'):
             n = args['--max_days']
             print(f"trimming cache to {n} days")
-            now = datetime.now(tz=timezone.utc)
-            cutoff = now - timedelta(days=n)
+            cutoff = (datetime.now(tz=timezone.utc) - timedelta(days=n)).strftime('%Y-%m-%d %H:%M:%S')
             sql = f"DELETE FROM cache WHERE updated < '{cutoff}'"
             cursor.execute(sql)
             print(f"deleted {cursor.rowcount} record(s)")

--- a/pipeline/sherlock/expire_cache.py
+++ b/pipeline/sherlock/expire_cache.py
@@ -1,0 +1,77 @@
+"""Utility to expire old cache entries. Expected to be run as a cron job.
+
+Usage:
+    expire_cache.py --database=URL --max_entries=MAX
+    expire_cache.py --database=URL --max_days=MAX
+    expire_cache.py --database=URL --min_version=VER
+
+Options:
+    --database=URL       Cache database (e.g. mysql://user:pw@host:3306/database)
+    --max_entries=MAX    Delete all entries in excess of MAX, oldest first
+    --max_days=DAYS      Delete all entries older than DAYS
+    --min_version=VER    Delete all entries with a version less than VER
+"""
+
+from docopt import docopt
+from packaging.version import Version
+from urllib.parse import urlparse
+from datetime import datetime, timezone, timedelta
+import pymysql.cursors
+
+
+def main(args):
+    url = urlparse(args['--database'])
+    connection = pymysql.connect(
+        host=url.hostname,
+        user=url.username,
+        password=url.password,
+        db=url.path.lstrip('/'),
+        charset='utf8mb4',
+        cursorclass=pymysql.cursors.DictCursor)
+    with (connection.cursor() as cursor):
+        if args.get('--max_entries'):
+            n = args['--max_entries']
+            print(f"trimming cache to {n} entries")
+            # get the nth entry
+            sql = f"SELECT * FROM cache ORDER BY updated DESC LIMIT 1 OFFSET {n-1}"
+            cursor.execute(sql)
+            row = cursor.fetchone()
+            if not row:
+                # cache is smaller than n
+                print(f"deleted 0 record(s)")
+                return
+            cutoff = row['updated']
+            sql = f"DELETE FROM cache WHERE updated < '{cutoff}'"
+            cursor.execute(sql)
+            print(f"deleted {cursor.rowcount} record(s)")
+        elif args.get('--max_days'):
+            n = args['--max_days']
+            print(f"trimming cache to {n} days")
+            now = datetime.now(tz=timezone.utc)
+            cutoff = now - timedelta(days=n)
+            sql = f"DELETE FROM cache WHERE updated < '{cutoff}'"
+            cursor.execute(sql)
+            print(f"deleted {cursor.rowcount} record(s)")
+        elif args.get('--min_version'):
+            min_ver = Version(args['--min_version'])
+            print(f"removing cache entries for versions prior to {min_ver}")
+            # get a list of versions
+            sql = f"SELECT DISTINCT version FROM cache"
+            cursor.execute(sql)
+            old_vers = []
+            for row in cursor.fetchall():
+                ver = Version(row['version'])
+                if ver < min_ver:
+                    old_vers.append(f"'{str(ver)}'")
+            if len(old_vers) == 0:
+                # nothing to do
+                print(f"deleted 0 record(s)")
+                return
+            sql = f"DELETE FROM cache WHERE version IN ({','.join(old_vers)})"
+            cursor.execute(sql)
+            print(f"deleted {cursor.rowcount} record(s)")
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    main(args)

--- a/pipeline/sherlock/wrapper.py
+++ b/pipeline/sherlock/wrapper.py
@@ -234,8 +234,9 @@ def classify(conf, log, alerts):
         # Syntax for ON DUPLICATE KEY appears to differ between MySQL and MariaDB :(
         # query = "INSERT INTO cache VALUES {} AS new ON DUPLICATE KEY UPDATE class=new.class,
         # crossmatch=new.crossmatch".format(",".join(values))
-        query = ("INSERT INTO cache (name, version, class, description, crossmatch) VALUES {} ON DUPLICATE KEY UPDATE version=VALUES(version), class=VALUES(class),\
-                 description=VALUES(description), crossmatch=VALUES(crossmatch)".format(",".join(values)))
+        query = ("INSERT INTO cache (name, version, class, description, crossmatch) VALUES {} ON DUPLICATE KEY UPDATE \
+                 version=VALUES(version), class=VALUES(class), description=VALUES(description), \
+                 crossmatch=VALUES(crossmatch)".format(",".join(values)))
         log.debug("update cache: {}".format(query))
         try:
             with connection.cursor() as cursor:

--- a/pipeline/sherlock/wrapper.py
+++ b/pipeline/sherlock/wrapper.py
@@ -234,7 +234,7 @@ def classify(conf, log, alerts):
         # Syntax for ON DUPLICATE KEY appears to differ between MySQL and MariaDB :(
         # query = "INSERT INTO cache VALUES {} AS new ON DUPLICATE KEY UPDATE class=new.class,
         # crossmatch=new.crossmatch".format(",".join(values))
-        query = ("INSERT INTO cache VALUES {} ON DUPLICATE KEY UPDATE version=VALUES(version), class=VALUES(class),\
+        query = ("INSERT INTO cache (name, version, class, description, crossmatch) VALUES {} ON DUPLICATE KEY UPDATE version=VALUES(version), class=VALUES(class),\
                  description=VALUES(description), crossmatch=VALUES(crossmatch)".format(",".join(values)))
         log.debug("update cache: {}".format(query))
         try:

--- a/tests/unit/pipeline/sherlock/test_sherlock_wrapper.py
+++ b/tests/unit/pipeline/sherlock/test_sherlock_wrapper.py
@@ -381,7 +381,8 @@ class SherlockWrapperClassifierTest(unittest.TestCase):
                 crossmatches = [{'transient_object_id': "177218944862519874", 'thing': 'foo'}]
                 mock_classifier.return_value.classify.return_value = (classifications, crossmatches)
                 cache = [{'name': '177218944862519874', 'version': sherlock_version, 'class': 'T', 'description': 't',
-                          'crossmatch': json.dumps(SherlockWrapperClassifierTest.crossmatches[0])}]
+                          'crossmatch': json.dumps(SherlockWrapperClassifierTest.crossmatches[0]),
+                          'updated': '2025-07-01 09:52:37'}]
                 mock_pymysql.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = cache
                 # should report classifying 1 alert
                 self.assertEqual(wrapper.classify(conf, log, alerts), 1)
@@ -419,7 +420,8 @@ class SherlockWrapperClassifierTest(unittest.TestCase):
                 crossmatches = [{'transient_object_id': "177218944862519874", 'thing': 'foo'}]
                 mock_classifier.return_value.classify.return_value = (classifications, crossmatches)
                 cache = [{'name': '177218944862519874', 'version': 'blah', 'class': 'T', 'description': 't',
-                          'crossmatch': json.dumps(SherlockWrapperClassifierTest.crossmatches[0])}]
+                          'crossmatch': json.dumps(SherlockWrapperClassifierTest.crossmatches[0]),
+                          'updated': '2025-07-01 09:52:37'}]
                 mock_pymysql.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = cache
                 # should report classifying 1 alert
                 self.assertEqual(wrapper.classify(conf, log, alerts), 1)
@@ -447,7 +449,8 @@ class SherlockWrapperClassifierTest(unittest.TestCase):
                 classifications = {"177218944862519874": ["QX", "A test"]}
                 crossmatches = [{'transient_object_id': "177218944862519874", 'thing': 'foo'}]
                 mock_classifier.return_value.classify.return_value = (classifications, crossmatches)
-                cache = [{'name': '177218944862519874', 'class': 'T', 'crossmatch': None}]
+                cache = [{'name': '177218944862519874', 'class': 'T', 'crossmatch': None,
+                          'updated': '2025-07-01 09:52:37'}]
                 mock_pymysql.return_value.cursor.return_value.__enter__.return_value.fetchall.return_value = cache
                 # should report classifying 1 alert
                 self.assertEqual(wrapper.classify(conf, log, alerts), 1)


### PR DESCRIPTION
Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/2612264961/How+to+do+Pull+Request#STEP-3%3A-Issue-a-Pull-Request-on-Github

# CHANGES

Adding the ability to expire old Sherlock cache entries - fixes #302 

- Add an `updated` timestamp column to the cache table
- Add a command line utility to expire old cache entries by number/date/version
- Add a crontab to invoke expire_cache
- Minor consequent changes to wrapper and tests
