### PR TITLE
Fix markdown link for rest-api.md in make_annotator.md

### DIFF
--- a/docs/source/core_functions/make_annotator.md
+++ b/docs/source/core_functions/make_annotator.md
@@ -38,7 +38,7 @@ There should be a file `settings.py` file to accomany the code below with these 
    * `TOPIC_OUT`: The name of your annotator as agreed with the Lasair team (above)
 
 If the code below is not clear, it would be good for you to read about how 
-the (Lasair client)[rest-api.html] works.
+the [Lasair client](rest-api.html) works.
 
 For more information about what is returned as `objectInfo`, a complete example 
 is [shown here](ZTF23aabplmy.html).


### PR DESCRIPTION
I noticed that the link in https://lasair-lsst.readthedocs.io/en/develop/core_functions/make_annotator.html#make-the-code
to rest-api.md was broken. Here's a fix.

exchange parens with square brackets

I would be happy to follow the checklist noted here, but don't have access to that page.
But this seems simple enough....

Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/2612264961/How+to+do+Pull+Request#STEP-3%3A-Issue-a-Pull-Request-on-Github

# CHANGES

- 
