### PR TITLE
fix crossmatch in case of timeout

### DIFF
--- a/common/src/run_crossmatch.py
+++ b/common/src/run_crossmatch.py
@@ -10,14 +10,18 @@ def distance(ra1, de1, ra2, de2):
     dde = (de1 - de2)
     return math.sqrt(dra*dra + dde*dde)
 
-def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
-    """ Delete all the hits and remake.
-    """
+def flip_hits(msl, wl_id):
     cursor  = msl.cursor(buffered=True, dictionary=True)
-    query = 'DELETE FROM watchlist_hits WHERE wl_id=%d' % wl_id
+
+    query = 'DELETE FROM watchlist_hits WHERE cone_id > 0 AND wl_id=%d' % wl_id
+    cursor.execute(query)
+
+    query = 'UPDATE watchlist_hits SET cone_id=-cone_id WHERE wl_id=%d' % wl_id
     cursor.execute(query)
     msl.commit()
 
+def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
+    cursor  = msl.cursor(buffered=True, dictionary=True)
     n_cones = 0
     n_hits = 0
     # get all the cones and run them
@@ -30,6 +34,7 @@ def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
             r = row['radius']
         n_hits += crossmatch(msl, wl_id, row['cone_id'], row['ra'], row['decl'], row['name'], r)
     message = "%d cones, %d hits" % (n_cones, n_hits)
+    flip_hits(msl, wl_id)
     return n_hits, message
 
 def crossmatch(msl, wl_id, cone_id, myRA, myDecl, name, radius):
@@ -46,9 +51,10 @@ def crossmatch(msl, wl_id, cone_id, myRA, myDecl, name, radius):
         arcsec = 3600*distance(myRA, myDecl, row['ra'], row['decl'])
         if arcsec > radius:
             continue
+        negative_cone_id = -cone_id
         n_hits += 1
         query3 = "INSERT INTO watchlist_hits (wl_id, cone_id, diaObjectId, arcsec, name) VALUES\n"
-        query3 += ' (%d, %d, "%s", %.2f, "%s")' % (wl_id, cone_id, objectId, arcsec, name)
+        query3 += ' (%d, %d, "%s", %.2f, "%s")' % (wl_id, negative_cone_id, objectId, arcsec, name)
         if 1:
             cursor3.execute(query3)
             msl.commit()

--- a/common/src/run_crossmatch.py
+++ b/common/src/run_crossmatch.py
@@ -10,16 +10,6 @@ def distance(ra1, de1, ra2, de2):
     dde = (de1 - de2)
     return math.sqrt(dra*dra + dde*dde)
 
-def flip_hits(msl, wl_id):
-    cursor  = msl.cursor(buffered=True, dictionary=True)
-
-    query = 'DELETE FROM watchlist_hits WHERE cone_id > 0 AND wl_id=%d' % wl_id
-    cursor.execute(query)
-
-    query = 'UPDATE watchlist_hits SET cone_id=-cone_id WHERE wl_id=%d' % wl_id
-    cursor.execute(query)
-    msl.commit()
-
 def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
     cursor  = msl.cursor(buffered=True, dictionary=True)
     n_cones = 0
@@ -34,7 +24,6 @@ def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
             r = row['radius']
         n_hits += crossmatch(msl, wl_id, row['cone_id'], row['ra'], row['decl'], row['name'], r)
     message = "%d cones, %d hits" % (n_cones, n_hits)
-    flip_hits(msl, wl_id)
     return n_hits, message
 
 def crossmatch(msl, wl_id, cone_id, myRA, myDecl, name, radius):
@@ -51,10 +40,9 @@ def crossmatch(msl, wl_id, cone_id, myRA, myDecl, name, radius):
         arcsec = 3600*distance(myRA, myDecl, row['ra'], row['decl'])
         if arcsec > radius:
             continue
-        negative_cone_id = -cone_id
         n_hits += 1
-        query3 = "INSERT INTO watchlist_hits (wl_id, cone_id, diaObjectId, arcsec, name) VALUES\n"
-        query3 += ' (%d, %d, "%s", %.2f, "%s")' % (wl_id, negative_cone_id, objectId, arcsec, name)
+        query3 = "INSERT IGNORE INTO watchlist_hits (wl_id, cone_id, diaObjectId, arcsec, name) VALUES\n"
+        query3 += ' (%d, %d, "%s", %.2f, "%s")' % (wl_id, cone_id, objectId, arcsec, name)
         if 1:
             cursor3.execute(query3)
             msl.commit()

--- a/common/src/run_crossmatch_optimised.py
+++ b/common/src/run_crossmatch_optimised.py
@@ -7,21 +7,6 @@ from fundamentals.logs import emptyLogger
 from HMpTy.mysql import conesearch
 from collections import defaultdict
 
-def flip_hits(dbConn, wl_id):
-
-    sqlQuery = 'DELETE FROM watchlist_hits WHERE cone_id > 0 AND wl_id=%d' % wl_id
-    writequery(
-        log=emptyLogger(),
-        sqlQuery=sqlQuery,
-        dbConn=dbConn
-    )
-    sqlQuery = 'UPDATE watchlist_hits SET cone_id=-cone_id WHERE wl_id=%d' % wl_id
-    writequery(
-        log=emptyLogger(),
-        sqlQuery=sqlQuery,
-        dbConn=dbConn
-    )
-
 def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
 
     dbSettings = {
@@ -142,14 +127,13 @@ def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
             dbTableName="watchlist_hits",
             dateCreated=False,
             batchSize=200000,
+            replace=True,
             dbSettings=dbSettings
         )
 
-    flip_hits(dbConn, wl_id)
     message = f"{n_hits} LSST objects have been associated with the {n_cones} sources in this watchlist"
     print(message)
     return n_hits, message
-
 
 if __name__ == "__main__":
     try:

--- a/common/src/run_crossmatch_optimised.py
+++ b/common/src/run_crossmatch_optimised.py
@@ -2,12 +2,12 @@ import math
 import sys
 sys.path.append('../common')
 import settings
-from fundamentals.mysql import database, readquery, writequery, insert_list_of_dictionaries_into_database_tables
-from fundamentals.logs import emptyLogger
-from HMpTy.mysql import conesearch
-from collections import defaultdict
 
 def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
+    from fundamentals.mysql import database, readquery, writequery, insert_list_of_dictionaries_into_database_tables
+    from fundamentals.logs import emptyLogger
+    from HMpTy.mysql import conesearch
+    from collections import defaultdict
 
     dbSettings = {
         'host': settings.DB_HOST,

--- a/common/src/run_crossmatch_optimised.py
+++ b/common/src/run_crossmatch_optimised.py
@@ -4,9 +4,9 @@ sys.path.append('../common')
 import settings
 
 def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
-    from fundamentals.mysql import database, readquery, writequery, insert_list_of_dictionaries_into_database_tables
-    from fundamentals.logs import emptyLogger
     from HMpTy.mysql import conesearch
+    from fundamentals.logs import emptyLogger
+    from fundamentals.mysql import database, readquery, writequery, insert_list_of_dictionaries_into_database_tables
     from collections import defaultdict
 
     dbSettings = {
@@ -105,10 +105,9 @@ def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
             # VALUES TO ADD TO DB
 
             for r, d, n, c, m in zip(raList, decList, nameList, coneIdList, matches.list):
-                negative_c = -c
                 keepDict = {
                     "wl_id": wl_id,
-                    "cone_id": negative_c,
+                    "cone_id": c,
                     "arcsec": m["cmSepArcsec"],
                     "name": n,
                     "diaObjectId": m["diaObjectId"]
@@ -134,6 +133,7 @@ def run_crossmatch(msl, radius, wl_id, batchSize=5000, wlMax=False):
     message = f"{n_hits} LSST objects have been associated with the {n_cones} sources in this watchlist"
     print(message)
     return n_hits, message
+
 
 if __name__ == "__main__":
     try:

--- a/tests/unit/common/src/test_run_crossmatch.py
+++ b/tests/unit/common/src/test_run_crossmatch.py
@@ -22,8 +22,8 @@ class RunCrossmatchTest(unittest.TestCase):
         # A small cone and a large cone
         wl_id = 1
         cones = [
-            {'cone_id':1, 'myRA':1.0, 'myDecl':1.0, 'radius':1.0,   'name':'small'},
-            {'cone_id':2, 'myRA':2.0, 'myDecl':1.0, 'radius':100.0, 'name':'large'},
+            {'cone_id':101, 'myRA':1.0, 'myDecl':1.0, 'radius':1.0,   'name':'small'},
+            {'cone_id':102, 'myRA':2.0, 'myDecl':1.0, 'radius':100.0, 'name':'large'},
         ]
 
         # A set of objects to run against
@@ -37,8 +37,8 @@ class RunCrossmatchTest(unittest.TestCase):
 
         # expected results
         expect_results = [
-            '(1,1,"123",0.51,"small")',
-            '(1,2,"125",72.00,"large")',
+            '(1,-101,"123",0.51,"small")',
+            '(1,-102,"125",72.00,"large")',
         ]
 
         mock_session = MagicMock()

--- a/tests/unit/common/src/test_run_crossmatch.py
+++ b/tests/unit/common/src/test_run_crossmatch.py
@@ -37,8 +37,8 @@ class RunCrossmatchTest(unittest.TestCase):
 
         # expected results
         expect_results = [
-            '(1,-101,"123",0.51,"small")',
-            '(1,-102,"125",72.00,"large")',
+            '(1,101,"123",0.51,"small")',
+            '(1,102,"125",72.00,"large")',
         ]
 
         mock_session = MagicMock()


### PR DESCRIPTION
- The old method deleted the watchlist_hits before building the new, so a timeout results in a half-baked list. 
- This new version makes the new list first, with negative value for cone_id, then does the delete and sign change
