### PR TITLE
Hotfix/ligtcurve updates

### DIFF
--- a/webserver/lasair/apps/object/utils.py
+++ b/webserver/lasair/apps/object/utils.py
@@ -335,7 +335,15 @@ def object_difference_lightcurve(
                 scrollers.forEach(function(scroller) {
                     scroller.remove();
                 });
+                let plots = document.querySelectorAll('.js-plotly-plot');
+                plot.on('plotly_relayout', function(eventData) {
+                    let scrollers = document.querySelectorAll('.x2y');
+                    scrollers.forEach(function(scroller) {
+                        scroller.remove();
+                    });
+                });
             });
+            
         """)
 
     return htmlLightcurve, mergedDF

--- a/webserver/lasair/apps/object/views.py
+++ b/webserver/lasair/apps/object/views.py
@@ -15,7 +15,7 @@ import os
 import sys
 from astropy.time import Time
 from lasair.utils import mjd_now, ecliptic_and_galactic, rasex, decsex, objjson
-from .utils import object_difference_lightcurve, object_difference_lightcurve_forcedphot
+from .utils import object_difference_lightcurve
 sys.path.append('../common')
 
 
@@ -60,8 +60,8 @@ def object_detail(request, diaObjectId):
     if 'sherlock' in data2:
         data2.pop('sherlock')
 
-    lightcurveHtml, mergedDF = object_difference_lightcurve(data)
-    fplightcurveHtml, mergedDF = object_difference_lightcurve_forcedphot(data)
+    lightcurveHtml, mergedDF = object_difference_lightcurve(data, forced=False)
+    fplightcurveHtml, mergedDF = object_difference_lightcurve(data, forced=True)
     if mergedDF is not None:
         lcData = mergedDF.to_dict('records')
     else:


### PR DESCRIPTION
This PR addressed issue #345

# CHANGES

- There are 2 plots for unforced and forced. Forced plot does not appear if there is no forced data to plot.
- Each plot has a radio button for log/linear. Flux is plotted in linear scale by default.
- Scale-changing and origin-changing are now synced between top-and-bottom and left-and-right axes. This was a pain in the *&(#!. I have disabled scrolling of the top axis as this was causing problems (and not needed ... use the bottom axis).
- RHS black axis bar now appears.
- Black text for tick markers.
- Double click is now working as expected
- Now using [Rubin's offical LC markers for plots](https://rtn-045.lsst.io/#colorblind-friendly-plots) (Roy already had the correct colours). 
