### PR TITLE
full diaSource data

### DIFF
--- a/deploy/common/settings.py.j2
+++ b/deploy/common/settings.py.j2
@@ -138,6 +138,9 @@ GRAFANA_USERNAME       = 'ztf'
 GRAFANA_PASSWORD       = '{{ settings.grafana_password }}'
 LASAIR_GRAFANA_URL     = "https://{{ lasair_name }}-svc.{{ domain }}/d/iILmd8-Wz/alerts"
 
+# Time to live for cutout images
+MAX_CUTOUT_DAYS        = 21
+
 # Watchlist and Area control
 ############################
 WATCHLIST_CHUNK        = 50000

--- a/webserver/lasair/apps/object/views.py
+++ b/webserver/lasair/apps/object/views.py
@@ -37,7 +37,8 @@ def object_detail(request, diaObjectId):
     ]
     ```           
     """
-    data = objjson(diaObjectId, lite=True)
+#    data = objjson(diaObjectId, lite=True)
+    data = objjson(diaObjectId, lite=False)
 
     # how to replace the real data with fake data
 #    with open('/home/ubuntu/fake.json', 'r') as f:
@@ -67,9 +68,12 @@ def object_detail(request, diaObjectId):
     else:
         lcData = data["diaSources"]
 
+    def my_json_encoder(obj):
+        return str(obj)
+
     return render(request, 'object/object_detail.html', {
         'data': data,
-        'json_data': json.dumps(data2),
+        'json_data': json.dumps(data2, default=my_json_encoder),
         'authenticated': request.user.is_authenticated,
         'lightcurveHtml': lightcurveHtml,
         'fplightcurveHtml': fplightcurveHtml,

--- a/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
@@ -65,7 +65,7 @@
 				    {% if cand.image_urls.Difference %} <a href='javascript:JS9Popout("/fits/{{ cand.diaSourceId }}_cutoutDifference");'><small>diff</small></a> {% endif %}
                             </td>
 
-                            <td> <a tabindex="0" class="disable"  data-bs-html="true"  data-bs-container="body" data-bs-toggle="popover" data-bs-trigger="focus" data-bs-placement="top" data-bs-content='<pre><code>{{cand.json}}</code></pre>'>data</a></td>
+                            <td> <a tabindex="0" class="disable"  data-bs-html="true"  data-bs-container="body" data-bs-toggle="popover" data-bs-trigger="click" data-bs-placement="top" data-bs-content='<pre><code>{{cand.json}}</code></pre>'>data</a></td>
 
                         </tr>
 

--- a/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
+++ b/webserver/lasair/templates/includes/widgets/widget_object_detection_table.html
@@ -48,6 +48,7 @@
                         <th>UTC</th>
                         <th>band</th>
                         <th>target diff flux</th>
+			<th>reliability</th>
                         <th>images</th>
                         <th>alert packet</th>
                     </tr></thead>
@@ -59,6 +60,7 @@
                             <td>{{ cand.utc }}</td>
 			    <td>{{ cand.band }}</td>
 			    <td>{{ cand.psfFlux|floatformat:0 }} &plusmn; {{ cand.psfFluxErr|floatformat:0 }}</td>
+			    <td>{{ cand.reliability|floatformat:2 }}</td>
                             <td>
 				    {% if cand.image_urls.Science %} <a href='javascript:JS9Popout("/fits/{{ cand.diaSourceId }}_cutoutScience");'><small>target</small></a> {% endif %}
 				    {% if cand.image_urls.Template %} <a href='javascript:JS9Popout("/fits/{{ cand.diaSourceId }}_cutoutTemplate");'><small>ref</small></a> {% endif %}

--- a/webserver/lasair/utils.py
+++ b/webserver/lasair/utils.py
@@ -16,7 +16,7 @@ from django.shortcuts import get_object_or_404
 from django.http import HttpResponse, HttpResponseRedirect
 from django.template.context_processors import csrf
 from django.http import JsonResponse
-#from django.conf import settings as django_settings
+from django.conf import settings as django_settings
 
 import dateutil.parser as dp
 from datetime import datetime, timedelta
@@ -216,13 +216,16 @@ def objjson(diaObjectId, lite=False):
         json_formatted_str = json.dumps(diaSource, indent=2)
         diaSource['json'] = json_formatted_str[1:-1]
         diaSource['mjd'] = mjd = float(diaSource['midpointMjdTai'])
-        diaSource['since_now'] = mjd - now
+        diaSource['since_now'] = since_now = now - mjd
         count_all_diaSources += 1
         diaSourceId = diaSource['diaSourceId']
         date = datetime.strptime("1858/11/17", "%Y/%m/%d")
         date += timedelta(mjd)
         diaSource['utc'] = date.strftime("%Y-%m-%d %H:%M:%S")
 
+        if since_now > lasair_settings.MAX_CUTOUT_DAYS: 
+            # cutouts after this time will be gone.
+            continue
         # ADD IMAGE URLS
         diaSource['image_urls'] = {}
         for cutoutType in ['Science', 'Template', 'Difference']:

--- a/webserver/lasair/utils.py
+++ b/webserver/lasair/utils.py
@@ -227,8 +227,8 @@ def objjson(diaObjectId, lite=False):
         diaSource['image_urls'] = {}
         for cutoutType in ['Science', 'Template', 'Difference']:
             diaSourceId_cutoutType = '%s_cutout%s' % (diaSourceId, cutoutType)
-            url = 'https://%s/fits/%d/%s'
-            url = url % (lasair_settings.LASAIR_URL, int(mjd), diaSourceId_cutoutType)
+            url = 'https://%s/fits/%s'
+            url = url % (lasair_settings.LASAIR_URL, diaSourceId_cutoutType)
             diaSource['image_urls'][cutoutType] = url
 
     if count_all_diaSources == 0:


### PR DESCRIPTION
- The object page has a table of past detections with links to cutouts. It also has a link to "data" to show the diaSource. But it has been restricted (see image). This PR puts the full data there (see image). Another small change enables copy/paste from the full data.

- It also debugs the imageUrls given out by the API

- Reduces the available cutout links to the last MAX_CUTOUT_DAYS = 21

- It also adds a column "reliability" to the tables of sources on the object page

# CHANGES
<img width="784" height="459" alt="lessData" src="https://github.com/user-attachments/assets/77e1f49f-44dd-4edd-b7cf-9a209436dd65" />
<img width="746" height="588" alt="moreData" src="https://github.com/user-attachments/assets/a5676b11-be4d-4c31-8364-9155ea1bef11" />


- 
