### PR TITLE
Rewrite and inclusion of Cassandra as well as MariaDB with check_schema.py

### DIFF
--- a/deploy/login.yaml
+++ b/deploy/login.yaml
@@ -75,6 +75,8 @@
           - fastavro
           - mysql.connector
           - parallel-ssh
+          - docopt
+          - cassandra-driver
         extra_args: "--break-system-packages"
 
   - name: Install vault snap

--- a/tests/system/deployment.yaml
+++ b/tests/system/deployment.yaml
@@ -72,6 +72,25 @@
       changed_when: false
   tags: db
 
+# cassandra tests
+- hosts: localhost
+  gather_facts: false
+  vars:
+    schemata:
+      - diaObjects
+      - diaSources
+      - diaForcedSources
+      - ssObjects
+      - ssSources
+  tasks:
+    - name: validate cassandra schemata
+      ansible.builtin.command:
+        chdir: ../../utility
+        cmd: "python3 check_schema.py --host=lasair-lsst-dev-cassandra-0 --port=9042 --mod={{ schema_mod }}.{{ item }}"
+      loop: "{{ schemata }}"
+      changed_when: false
+  tags: db
+
 # kafka tests
 - hosts: kafka, kafka_pub
   gather_facts: false

--- a/tests/system/deployment.yaml
+++ b/tests/system/deployment.yaml
@@ -250,7 +250,7 @@
     - name: validate cassandra schemata
       ansible.builtin.command:
         chdir: ../../utility
-        cmd: "python3 check_schema.py --cassandra --host=lasair-lsst-dev-cassandranodes-0 --port=9042 --mod={{ schema_mod }}.{{ item }}"
+        cmd: "python3 check_schema.py --cassandra --host={{ groups['cassandranodes'][0] }} --port=9042 --mod={{ schema_mod }}.{{ item }}"
       loop: "{{ schemata }}"
       changed_when: false
   tags: cassandra

--- a/tests/system/deployment.yaml
+++ b/tests/system/deployment.yaml
@@ -72,25 +72,6 @@
       changed_when: false
   tags: db
 
-# cassandra tests
-- hosts: localhost
-  gather_facts: false
-  vars:
-    schemata:
-      - diaObjects
-      - diaSources
-      - diaForcedSources
-      - ssObjects
-      - ssSources
-  tasks:
-    - name: validate cassandra schemata
-      ansible.builtin.command:
-        chdir: ../../utility
-        cmd: "python3 check_schema.py --host=lasair-lsst-dev-cassandra-0 --port=9042 --mod={{ schema_mod }}.{{ item }}"
-      loop: "{{ schemata }}"
-      changed_when: false
-  tags: db
-
 # kafka tests
 - hosts: kafka, kafka_pub
   gather_facts: false
@@ -251,6 +232,27 @@
         port: 9042
         timeout: 1
       tags: net
+  tags: cassandra
+
+# cassandra schema test
+- hosts: localhost
+  gather_facts: false
+  vars_files:
+    - system_test_settings.yaml
+  vars:
+    schemata:
+      - diaObjects
+      - diaSources
+      - diaForcedSources
+      - ssObjects
+      - ssSources
+  tasks:
+    - name: validate cassandra schemata
+      ansible.builtin.command:
+        chdir: ../../utility
+        cmd: "python3 check_schema.py --cassandra --host=lasair-lsst-dev-cassandranodes-0 --port=9042 --mod={{ schema_mod }}.{{ item }}"
+      loop: "{{ schemata }}"
+      changed_when: false
   tags: cassandra
 
 # cutout cassandra tests

--- a/utility/check_schema.py
+++ b/utility/check_schema.py
@@ -3,88 +3,185 @@
 Validate the schema used in the object database against the JSON version of the schema in git.
 Raises an AssertionError and returns with non-zero if the number of fields or names of fields
 differ (types are not checked).
+
+Usage:
+  check_schema.py [--user=<user>] [--password=<pwd>] [--host=<host>] [--port=<port>] [--database=<db>]
+                  [--format=<fmt>] (--mod=<mod> | --url=<url>) [--cassandra]
+  check_schema.py (-h | --help)
+
+Options:
+  -h --help                    Show this help message.
+  --user=<user>                MySQL username [default: ztf].
+  --password=<pwd>             MySQL password.
+  --host=<host>                MySQL hostname or Cassandra contact point.
+  --port=<port>                MySQL or Cassandra port number [default: 3306].
+  --database=<db>              Name of database or Cassandra keyspace [default: ztf].
+  --format=<fmt>               Schema format (json|py) [default: py].
+  --mod=<mod>                  Module to import the schema from.
+  --url=<url>                  URL to get the schema from.
+  --cassandra                  Do a schema check against cassandra, not MySQL.
+
+E.g.
+  python %s --user=dbuser --password=dbpass --host=localhost --port=3306 --database=dbname --mod=9_0_A.objects
+  python %s --host=localhost --port=9042 --database=lasair --cassandra --mod=9_0_A.diaObjects
+
+  python %s --user=dbuser --password=dbpass --host=localhost --port=3306 --database=dbname --url=https://raw.githubusercontent.com/lsst-uk/lasair-lsst/refs/heads/develop/common/schema/9_0_A/objects.py
+  python %s --host=localhost --port=9042 --database=lasair --cassandra --url=https://raw.githubusercontent.com/lsst-uk/lasair-lsst/refs/heads/develop/common/schema/9_0_A/diaObjects.py
 """
 
 import sys
+__doc__ = __doc__ % (sys.argv[0], sys.argv[0], sys.argv[0], sys.argv[0])
 import json
 import mysql.connector
 import requests
-import argparse
 import re
 from importlib import import_module
+from docopt import docopt
+import yaml
 
 sys.path.append('../common')
 
 def get_mysql_names(conf):
-    config = {
-      'user': conf['user'], 
-      'password': conf['password'], 
-      'host': conf['host'], 
-      'port': conf['port'], 
-      'database': conf['database'], 
-      }
-    msl = mysql.connector.connect(**config)
+    """Get column names (and types) from MySQL
 
+    Args:
+        conf (dict): The config settings
+
+    Returns:
+        dict: A dictionary of columns and types
+    """
+
+    config = {
+      'user': conf['user'],
+      'password': conf['password'],
+      'host': conf['host'],
+      'port': int(conf['port']),
+      'database': conf['database'],
+    }
+    if conf['mod']:
+        table = conf['mod'].split('.')[-1]
+    else:
+        table = conf['url'].split('/')[-1].split('.')[-2]
+
+    msl = mysql.connector.connect(**config)
     cursor = msl.cursor(buffered=True, dictionary=True)
-    query = 'describe objects'
-    cursor.execute(query)
-    mysql_names = []
-    for row in cursor:
-        mysql_names.append(row['Field'])
+    cursor.execute("select column_name, column_type from information_schema.columns where table_name=%s", (table,))
+    mysql_names = [row['column_name'] for row in cursor]
     return mysql_names
 
+
+def get_cassandra_names(conf):
+    """Get column names (and types) from Cassandra
+
+    Args:
+        conf (dict): The config settings
+
+    Returns:
+        dict: A dictionary of columns and types
+    """
+
+    from cassandra.cluster import Cluster
+    from cassandra.query import dict_factory
+
+    if conf['mod']:
+        table = conf['mod'].split('.')[-1].lower()
+    else:
+        table = conf['url'].split('/')[-1].split('.')[-2].lower()
+
+    print("TABLE =", table)
+
+    cluster = Cluster([conf['host']], port=int(conf['port']))
+    session = cluster.connect()
+    session.row_factory = dict_factory
+
+    query = """
+      SELECT column_name, type
+      FROM system_schema.columns
+      WHERE keyspace_name=%s AND table_name=%s;
+    """
+    rows = session.execute(query, (conf['database'], table))
+    cassandra_names = [row['column_name'] for row in rows]
+    return cassandra_names
+
+
 def get_schema_names(conf):
+    """Get the schema information from a (mod) or remote (url) python file
+
+    Args:
+        conf (dict): The config settings
+
+    Returns:
+        dict: A dictionary of columns and types
+    """
+
     global schema_package
     schema_names = []
     if conf['url']:
         schema_text = requests.get(conf['url']).text
-        # if schema format is python then convert to json first
         if conf['format'] == 'py':
             schema_text = re.sub("^.*{", "{", schema_text, count=1)
             schema_text = re.sub("#.*", "", schema_text)
-        schema = json.loads(schema_text)
+            # 2025-11-25 KWS The "with" key for cutouts has multi-line triple quotes. Can't read this
+            #                with YAML or JSON. So get rid of it.
+            schema_text = re.sub(r'"with"\s*:\s*""".*?"""','"with": ""',schema_text,flags=re.DOTALL)
+
+        # 2025-11-25 KWS Use YAML, not JSON, since the 'indexes' key in Cassandra objects is not valid JSON.
+        #                YAML will read it OK, since it is more forgiving.
+        schema = yaml.safe_load(schema_text)
+        schema.pop("with", None) 
     else:
         schema = schema_package.schema
-    for field in schema['fields'] + schema['ext_fields']:
+    try:
+        fields = schema['fields'] + schema['ext_fields']
+    except KeyError as e:
+        fields = schema['fields']
+
+    for field in fields:
         if 'name' in field:
             schema_names.append(field['name'])
     return schema_names
 
+
 if __name__ == "__main__":
-    # parse cmd line arguments
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--user', default='ztf', type=str, help='MySQL username')
-    parser.add_argument('--password', type=str, help='MySQL password')
-    parser.add_argument('--host', type=str, help='MySQL hostname')
-    parser.add_argument('--port', type=int, default=3306, help='MySQL port number')
-    parser.add_argument('--database', type=str, default='ztf', help='Name of database')
-    parser.add_argument('--format', type=str, default='py', help='Schema format (json|py)')
-    parser.add_argument('--mod', type=str, help='module to import the schema from')
-    parser.add_argument('--url', type=str, help='URL to get the schema from')
-    conf = vars(parser.parse_args())
+    args = docopt(__doc__)
+
+    conf = {
+        'user': args['--user'],
+        'password': args['--password'],
+        'host': args['--host'],
+        'port': args['--port'],
+        'database': args['--database'],
+        'format': args['--format'],
+        'mod': args['--mod'],
+        'url': args['--url'],
+        'cassandra': args['--cassandra'],
+    }
 
     if not bool(conf['mod']) ^ bool(conf['url']):
-        print("Please specify exactly one of -mod and --url")
-        sys.exit()
+        print("Please specify exactly one of --mod or --url")
+        sys.exit(1)
 
     if conf['mod']:
         schema_package = import_module('schema.' + conf['mod'])
 
     schema_names = get_schema_names(conf)
 
-    mysql_names = get_mysql_names(conf)
+    if conf['cassandra']:
+        database_names = get_cassandra_names(conf)
+    else:
+        database_names = get_mysql_names(conf)
 
-    for mname in mysql_names:
+    for mname in database_names:
         if mname not in schema_names:
-            print(mname, ' in mysql but not in schema')
+            print(mname, 'in backend database but not in schema')
     for sname in schema_names:
-        if sname not in mysql_names:
-            print(sname, ' in schema but not in mysql')
+        if sname not in database_names:
+            print(sname, 'in schema but not in backend database')
 
-    assert len(mysql_names) == len(schema_names), "Schema validation failed: different length"
+    assert len(database_names) == len(schema_names), "Schema validation failed: different length"
 
-    for i in range(len(mysql_names)):
-        assert mysql_names.sort() == schema_names.sort(), "Schema validation failed: {} != {}".format(mysql_names, schema_names)
+    database_names.sort()
+    schema_names.sort()
+    assert database_names == schema_names, f"Schema validation failed: {database_names} != {schema_names}"
 
-    print('mysql and object schema identical')
-
+    print('Backend database and object schema are identical')


### PR DESCRIPTION
Substantial rewrite of `check_schema.py` to make it compatible with both MariaDB and Cassandra.

Death to argparse! Long live docopt!

Replaced json reader with YAML, since YAML is more forgiving when reading a JSON-like file that is NOT valid JSON - e.g. all the cassandra schema files have a key in single quotes. Had to replace the `with` key for the cassandra files with blank to make it read correctly.

For future enhancement, we now read both the `column_name` and (`column_`)`type` in both cases, so in future we could check that the column type matches correctly too (though we will need a quick lookup table to translate between - e.g `bigint` and `long`, `ascii`, `string`, `varchar` etc.)
