### PR TITLE
Further watchlist crossmatching optimisation 

### DIFF
--- a/deploy/roles/lasair_service/tasks/main.yml
+++ b/deploy/roles/lasair_service/tasks/main.yml
@@ -33,6 +33,7 @@
       - fink-client
       - lasair
       - skytag
+      - tqdm
 
 - name: Install more python packages
   become: yes

--- a/docs/source/core_functions/watchlists.md
+++ b/docs/source/core_functions/watchlists.md
@@ -67,7 +67,7 @@ The upload form is shown here:
 Fill in the name and description of the watchlist. Choose a default value of the 
 radius to use in matching, in arcseconds. 
 Each line should be RA, Dec, ID, and may have a fourth entry, the radius to use in matching, 
-in arcseconds, if different from the default. Then click “Create”.
+in arcseconds, if different from the default. The maximum radius allowed is 1800 arcsec, and radii greater than this value will be reduced to 1800 arcsec. Then click “Create”.
 
 Here is a successful creation of a watchlist. Some messages – “Bad line” – because there were 
 some lines without data, but you can ignore these, and look for where it 

--- a/webserver/lasair/templates/includes/widgets/widget_watchlist_create_form.html
+++ b/webserver/lasair/templates/includes/widgets/widget_watchlist_create_form.html
@@ -10,8 +10,7 @@
             </div>
             <div class="modal-body px-md-5">
                 <h2 class="h4 text-center">Create New Watchlist</h2>
-                <p class="text-center"><small class="text-gray-500">
-                    A Watchlist is composed of a set of locations in the sky, together with an association radius in arcseconds. These locations are presumably coordinates of sources of specific interest to you. Use a Watchlist to be alerted of transient events found in association with any of these sources. Your Watchlists will appear in the </em>My Watchlists</em> of the Watchlists index.
+                <p class="text-center"><small class="text-gray-500">A Watchlist is composed of a set of locations in the sky, together with an association radius in arcseconds. These locations are presumably coordinates of sources of specific interest to you. Use a Watchlist to be alerted of transient events found in association with any of these sources. Your Watchlists will appear in the </em>My Watchlists</em> of the Watchlists index.
             </small>
         </p>
 
@@ -46,7 +45,7 @@
             </div>
 
             <div class="form-group mb-4">
-                <label for="radius">Association radius (arcsec){% include "includes/info_tooltip.html" with info="The is the default search radius for your catalogue. If individual sources in your catalogue include their own association radii these will be used instead" position="auto" link=docroot|add:"/core_functions/watchlists.html" %}</label>
+                <label for="radius">Association radius (arcsec){% include "includes/info_tooltip.html" with info="The is the default search radius for your catalogue. If individual sources in your catalogue include their own association radii these will be used instead. The maximum radius allowed is 1800 arcsec." position="auto" link=docroot|add:"/core_functions/watchlists.html" %}</label>
                 <div class="input-group">
                     {{ form.radius|add_class:"form-control" }}
                 </div>

--- a/webserver/lasair/templates/includes/widgets/widget_watchlist_update_form.html
+++ b/webserver/lasair/templates/includes/widgets/widget_watchlist_update_form.html
@@ -41,7 +41,7 @@
                     </div>
 
                     <div class="form-group mb-4">
-                        <label for="radius">Association radius (arcsec){% include "includes/info_tooltip.html" with info="The is the default search radius for your catalogue. If individual sources in your catalogue include their own association radii these will be used instead" position="auto" link=docroot|add:"/core_functions/watchlists.html" %}</label>
+                        <label for="radius">Association radius (arcsec){% include "includes/info_tooltip.html" with info="The is the default search radius for your catalogue. If individual sources in your catalogue include their own association radii these will be used instead. The maximum radius allowed is 1800 arcsec." position="auto" link=docroot|add:"/core_functions/watchlists.html" %}</label>
                         <div class="input-group">
                             {{ form.radius|add_class:"form-control" }}
                         </div>


### PR DESCRIPTION
This was triggered by @HeloiseS's watchlist containing many large and heterogeneous radii. I've updated the optimised crossmatch code to batch the conesearches into crude bins (e.g. 10, 100, 500, 1000 arsec), with radius^2 defining the number of sources to batch into each MySQL query. The code now runs in ~1min on the dev platform.

Further optimistation can be done if we had HTMs 07, 10 and 13 cached in the objects table.

# CHANGES

- optimisations in run conesearch code
- updated tooltip and docs to state that "_The maximum radius allowed is 1800 arcsec, and radii greater than this value will be reduced to 1800 arcsec."_ (we may need to reduce this further).
