### PR TITLE
stop spurious slack messages

### DIFF
--- a/services/make_area_files.py
+++ b/services/make_area_files.py
@@ -122,6 +122,7 @@ if __name__ == "__main__":
             execute_cmd('rm ' + area_file, logfile)
             logf.write('Area %s not active: %s' % (ar_id, message))
 
-    execute_cmd('rm -r %s'  % cache_dir, logfile)
+    if os.path.exists(cache_dir):
+        execute_cmd('rm -r %s'  % cache_dir, logfile)
     execute_cmd('mv %s %s' % (new_cache_dir, cache_dir), logfile)
     sys.exit(0)

--- a/services/make_watchlist_files.py
+++ b/services/make_watchlist_files.py
@@ -189,7 +189,10 @@ def rebuild_cache(wl_id, name, cones, max_depth, cache_dir, chk):
             % (name, len(ralist), time.time() - t))
 
     # move the new stuff into the correct directory name
-    cmd = 'rm -r %s; mv %s %s' % (watchlist_dir, watchlist_dir_new, watchlist_dir)
+    if os.path.exists(watchlist_dir):
+        cmd = 'rm -r %s' % watchlist_dir
+        execute_cmd(cmd, logfile)
+    cmd = 'mv %s %s' % (watchlist_dir_new, watchlist_dir)
     execute_cmd(cmd, logfile)
 
 if __name__ == "__main__":


### PR DESCRIPTION
With make_watchlist_files and make_area_files, there is a "rm directory" command that can cause a spurious slack error if the 
