### PR TITLE
Add/kafka lightcurve

### DIFF
--- a/pipeline/filter/filtercore.py
+++ b/pipeline/filter/filtercore.py
@@ -71,24 +71,6 @@ sys.path.append('features/BBB')
 def now():
     return datetime.datetime.now(datetime.UTC).strftime("%H:%M:%S")
 
-def lightcurve_lite(alert):
-    d = {
-        'psfFlux':[], 
-        'psfFluxErr':[], 
-        'midpointMjdTai':[], 
-        'band':[], 
-        'reliability':[]}
-    sources = sorted(alert['diaSourcesList'], 
-        key=lambda source: source['midpointMjdTai'])
-    sources = [s for s in sources if s['psfFlux'] is not None]
-    for s in sources:
-        d['psfFlux']       .append(s['psfFlux'])
-        d['psfFluxErr']    .append(s['psfFluxErr'])
-        d['midpointMjdTai'].append(s['midpointMjdTai'])
-        d['band']          .append(s['band'])
-        d['reliability']   .append(s['reliability'])
-    return d
-
 class Filter:
     """Filter orchestrates the filter pipeline stage.
     """
@@ -114,7 +96,7 @@ class Filter:
         self.stats = stats
         self.verbose = verbose
         self.sfd = None
-        self.lightcurve_dict = {}
+        self.alert_dict = {}
 
         self.consumer = None
         self.database = None
@@ -392,7 +374,7 @@ class Filter:
             nalert_in += 1
             alertList.append(alert)
             diaObjectId = alert['diaObject']['diaObjectId']
-            self.lightcurve_dict[diaObjectId] = lightcurve_lite(alert)
+            self.alert_dict[diaObjectId] = alert
 
             if nalert_in % 1000 == 0:
                 d = self.handle_alert_list(alertList)

--- a/pipeline/filter/filtercore.py
+++ b/pipeline/filter/filtercore.py
@@ -71,6 +71,23 @@ sys.path.append('features/BBB')
 def now():
     return datetime.datetime.now(datetime.UTC).strftime("%H:%M:%S")
 
+def lightcurve_lite(alert):
+    d = {
+        'psfFlux':[], 
+        'psfFluxErr':[], 
+        'midpointMjdTai':[], 
+        'band':[], 
+        'reliability':[]}
+    sources = sorted(alert['diaSourcesList'], 
+        key=lambda source: source['midpointMjdTai'])
+    sources = [s for s in sources if s['psfFlux'] is not None]
+    for s in sources:
+        d['psfFlux']       .append(s['psfFlux'])
+        d['psfFluxErr']    .append(s['psfFluxErr'])
+        d['midpointMjdTai'].append(s['midpointMjdTai'])
+        d['band']          .append(s['band'])
+        d['reliability']   .append(s['reliability'])
+    return d
 
 class Filter:
     """Filter orchestrates the filter pipeline stage.
@@ -97,6 +114,7 @@ class Filter:
         self.stats = stats
         self.verbose = verbose
         self.sfd = None
+        self.lightcurve_dict = {}
 
         self.consumer = None
         self.database = None
@@ -373,6 +391,8 @@ class Filter:
 
             nalert_in += 1
             alertList.append(alert)
+            diaObjectId = alert['diaObject']['diaObjectId']
+            self.lightcurve_dict[diaObjectId] = lightcurve_lite(alert)
 
             if nalert_in % 1000 == 0:
                 d = self.handle_alert_list(alertList)

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -194,10 +194,10 @@ def dispose_query_results(query, query_results, fltr=None):
         if not fltr or fltr.send_email:
             last_email = dispose_email(allrecords, last_email, query)
 
-    if active == 2:
+    if active > 2:
         # send results by kafka on given topic
         if not fltr or fltr.send_kafka:
-            if fltr.active = 3:
+            if active == 3:
                 for q in query_results:
                     diaObjectId = q['diaObjectId']
                     q['lightcurve'] = fltr.lightcurve_dict[diaObjectId]

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -190,10 +190,10 @@ def lightcurve_lite(alert):
 
     attrList = ['psfFlux', 'psfFluxErr', 'midpointMjdTai', 'band']
     diaForcedSourcesList = []
-    for ds in alert['diaForcedSourcesList']:
+    for dfs in alert['diaForcedSourcesList']:
         diaForcedSource = {}
         for attr in attrList:
-            diaForcedSource[attr] = ds[attr]
+            diaForcedSource[attr] = dfs[attr]
         diaForcedSourcesList.append(diaForcedSource)
 
     return {

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -220,12 +220,18 @@ def dispose_query_results(query, query_results, fltr=None):
         if not fltr or fltr.send_kafka:
             if active == 3:   # append lightcurve lite
                 for q in query_results:
-                    diaObjectId = q['diaObjectId']
-                    q['alert'] = lightcurve_lite(fltr.alert_dict[diaObjectId])
+                    try:
+                        diaObjectId = q['diaObjectId']
+                        q['alert'] = lightcurve_lite(fltr.alert_dict[diaObjectId])
+                    except:
+                        pass
             if active == 4:   # append full alert
                 for q in query_results:
-                    diaObjectId = q['diaObjectId']
-                    q['alert'] = fltr.alert_dict[diaObjectId]
+                    try:
+                        diaObjectId = q['diaObjectId']
+                        q['alert'] = fltr.alert_dict[diaObjectId]
+                    except:
+                        pass
             dispose_kafka(query_results, query['topic_name'])
 
     utcnow = datetime.datetime.now(datetime.UTC)

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -197,6 +197,10 @@ def dispose_query_results(query, query_results, fltr=None):
     if active == 2:
         # send results by kafka on given topic
         if not fltr or fltr.send_kafka:
+            if fltr.active = 3:
+                for q in query_results:
+                    diaObjectId = q['diaObjectId']
+                    q['lightcurve'] = fltr.lightcurve_dict[diaObjectId]
             dispose_kafka(query_results, query['topic_name'])
 
     utcnow = datetime.datetime.now(datetime.UTC)

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -179,6 +179,27 @@ def run_query(query, msl, annotator=None, diaObjectId=None, fltr=None):
 
     return query_results
 
+def lightcurve_lite(alert):
+    attrList = ['psfFlux', 'psfFluxErr', 'midpointMjdTai', 'band', 'reliability']
+    diaSourcesList = []
+    for ds in alert['diaSourcesList']:
+        diaSource = {}
+        for attr in attrList:
+            diaSource[attr] = ds[attr]
+        diaSourcesList.append(diaSource)
+
+    attrList = ['psfFlux', 'psfFluxErr', 'midpointMjdTai', 'band']
+    diaForcedSourcesList = []
+    for ds in alert['diaForcedSourcesList']:
+        diaForcedSource = {}
+        for attr in attrList:
+            diaForcedSource[attr] = ds[attr]
+        diaForcedSourcesList.append(diaForcedSource)
+
+    return {
+        "diaSourcesList": diaSourcesList,
+        "diaForcedSourcesList": diaForcedSourcesList,
+    }
 
 def dispose_query_results(query, query_results, fltr=None):
     """ Send out the query results by email or kafka, and ipdate the digest file
@@ -197,10 +218,14 @@ def dispose_query_results(query, query_results, fltr=None):
     if active > 2:
         # send results by kafka on given topic
         if not fltr or fltr.send_kafka:
-            if active == 3:
+            if active == 3:   # append lightcurve lite
                 for q in query_results:
                     diaObjectId = q['diaObjectId']
-                    q['lightcurve'] = fltr.lightcurve_dict[diaObjectId]
+                    q['alert'] = lightcurve_lite(fltr.alert_dict[diaObjectId])
+            if active == 4:   # append full alert
+                for q in query_results:
+                    diaObjectId = q['diaObjectId']
+                    q['alert'] = fltr.alert_dict[diaObjectId]
             dispose_kafka(query_results, query['topic_name'])
 
     utcnow = datetime.datetime.now(datetime.UTC)

--- a/tests/unit/pipeline/filter/sample_alerts/Tidal_disruption_event_TDE_114933870_lite.json
+++ b/tests/unit/pipeline/filter/sample_alerts/Tidal_disruption_event_TDE_114933870_lite.json
@@ -1,0 +1,166 @@
+{
+  "diaSourcesList": [
+    {
+      "psfFlux": 99.948372,
+      "psfFluxErr": 11.974789,
+      "midpointMjdTai": 60102.2511,
+      "band": "y",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 4.337743,
+      "psfFluxErr": 11.536114,
+      "midpointMjdTai": 59998.3902,
+      "band": "z",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 35.664677,
+      "psfFluxErr": 55.362003,
+      "midpointMjdTai": 60008.3373,
+      "band": "y",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 13.662395,
+      "psfFluxErr": 9.703589,
+      "midpointMjdTai": 60012.376,
+      "band": "z",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": -5.406483,
+      "psfFluxErr": 10.790968,
+      "midpointMjdTai": 60013.3903,
+      "band": "z",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 6.498031,
+      "psfFluxErr": 16.970562,
+      "midpointMjdTai": 60014.3992,
+      "band": "z",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 5.635691,
+      "psfFluxErr": 14.052308,
+      "midpointMjdTai": 60021.4093,
+      "band": "z",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 0.496679,
+      "psfFluxErr": 2.638094,
+      "midpointMjdTai": 60022.3448,
+      "band": "g",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 120.486488,
+      "psfFluxErr": 11.407612,
+      "midpointMjdTai": 60027.2841,
+      "band": "u",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 143.287079,
+      "psfFluxErr": 17.636774,
+      "midpointMjdTai": 60037.255,
+      "band": "y",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 160.419266,
+      "psfFluxErr": 31.153305,
+      "midpointMjdTai": 60039.2729,
+      "band": "y",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 210.949493,
+      "psfFluxErr": 11.304659,
+      "midpointMjdTai": 60042.3635,
+      "band": "z",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 403.491211,
+      "psfFluxErr": 7.155134,
+      "midpointMjdTai": 60051.2632,
+      "band": "r",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 336.098511,
+      "psfFluxErr": 7.576153,
+      "midpointMjdTai": 60059.3095,
+      "band": "i",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 342.084045,
+      "psfFluxErr": 6.997466,
+      "midpointMjdTai": 60061.3037,
+      "band": "i",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 436.266937,
+      "psfFluxErr": 8.663075,
+      "midpointMjdTai": 60062.2128,
+      "band": "r",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 338.922699,
+      "psfFluxErr": 9.903556,
+      "midpointMjdTai": 60064.2821,
+      "band": "i",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 255.319992,
+      "psfFluxErr": 28.849985,
+      "midpointMjdTai": 60068.2526,
+      "band": "y",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 256.866913,
+      "psfFluxErr": 12.630905,
+      "midpointMjdTai": 60069.2683,
+      "band": "z",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 268.823151,
+      "psfFluxErr": 12.982125,
+      "midpointMjdTai": 60070.2925,
+      "band": "z",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 215.283203,
+      "psfFluxErr": 29.700726,
+      "midpointMjdTai": 60071.2999,
+      "band": "y",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 531.107239,
+      "psfFluxErr": 13.407353,
+      "midpointMjdTai": 60077.2146,
+      "band": "g",
+      "reliability": 0.0
+    },
+    {
+      "psfFlux": 346.082886,
+      "psfFluxErr": 6.836234,
+      "midpointMjdTai": 60083.2617,
+      "band": "r",
+      "reliability": 0.0
+    }
+  ],
+  "diaForcedSourcesList": []
+}

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -94,7 +94,7 @@ class FeatureTest(TestCase):
       output = FeatureGroup.run_all(alert, verbose=True)
       self.assertTrue(isinstance(output, dict))
 
-  def test5_run_all(self):
+  def test5_lightcurve_lite(self):
     """Test the lightcurve_lite method"""
     from filters import lightcurve_lite
     with open("sample_alerts/%s.json"%sample) as f_in, open("sample_alerts/%s_lite.json"%sample) as f_out:

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -94,6 +94,15 @@ class FeatureTest(TestCase):
       output = FeatureGroup.run_all(alert, verbose=True)
       self.assertTrue(isinstance(output, dict))
 
+  def test5_run_all(self):
+    """Test the lightcurve_lite method"""
+    from filters import lightcurve_lite
+    with open("sample_alerts/%s.json"%sample) as f_in, open("sample_alerts/%s_lite.json"%sample) as f_out:
+      alert = modify(json.load(f_in))
+      output = lightcurve_lite(alert)
+      sample_output = json.load(f_out)
+      self.assertEqual(output, sample_output)
+
 if __name__ == '__main__':
   import xmlrunner
   runner = xmlrunner.XMLTestRunner(output='test-reports')

--- a/tests/unit/pipeline/filter/test_feature_groups.py
+++ b/tests/unit/pipeline/filter/test_feature_groups.py
@@ -94,6 +94,8 @@ class FeatureTest(TestCase):
       output = FeatureGroup.run_all(alert, verbose=True)
       self.assertTrue(isinstance(output, dict))
 
+  # This tests is not actually part of feature groups
+  # Should be moved to filters once those tests exist
   def test5_lightcurve_lite(self):
     """Test the lightcurve_lite method"""
     from filters import lightcurve_lite

--- a/webserver/lasair/apps/filter_query/forms.py
+++ b/webserver/lasair/apps/filter_query/forms.py
@@ -108,7 +108,8 @@ class filterQueryForm(forms.ModelForm):
         notificationTypes = (
             (0, 'muted'),
             (1, 'email stream (daily)'),
-            (2, 'kafka stream')
+            (2, 'kafka stream'),
+            (3, 'kafka stream with lightcurves'),
         )
         model = filter_query
         widgets = {
@@ -196,7 +197,8 @@ class UpdateFilterQueryForm(forms.ModelForm):
         notificationTypes = (
             (0, 'muted'),
             (1, 'email stream (daily)'),
-            (2, 'kafka stream')
+            (2, 'kafka stream'),
+            (3, 'kafka stream with lightcurves'),
         )
         model = filter_query
         widgets = {
@@ -242,7 +244,8 @@ class DuplicateFilterQueryForm(forms.ModelForm):
         notificationTypes = (
             (0, 'muted'),
             (1, 'email stream (daily)'),
-            (2, 'kafka stream')
+            (2, 'kafka stream'),
+            (3, 'kafka stream with lightcurves'),
         )
         model = filter_query
         widgets = {

--- a/webserver/lasair/apps/filter_query/forms.py
+++ b/webserver/lasair/apps/filter_query/forms.py
@@ -109,8 +109,8 @@ class filterQueryForm(forms.ModelForm):
             (0, 'muted'),
             (1, 'email stream (daily)'),
             (2, 'kafka stream'),
-            (3, 'kafka stream with lite lightcurves'),
-            (4, 'kafka stream with full lightcurves'),
+            (3, 'kafka stream with lite lightcurve'),
+            (4, 'kafka stream with full alert'),
         )
         model = filter_query
         widgets = {
@@ -199,8 +199,8 @@ class UpdateFilterQueryForm(forms.ModelForm):
             (0, 'muted'),
             (1, 'email stream (daily)'),
             (2, 'kafka stream'),
-            (3, 'kafka stream with lite lightcurves'),
-            (4, 'kafka stream with full lightcurves'),
+            (3, 'kafka stream with lite lightcurve'),
+            (4, 'kafka stream with full alert'),
         )
         model = filter_query
         widgets = {
@@ -247,8 +247,8 @@ class DuplicateFilterQueryForm(forms.ModelForm):
             (0, 'muted'),
             (1, 'email stream (daily)'),
             (2, 'kafka stream'),
-            (3, 'kafka stream with lite lightcurves'),
-            (4, 'kafka stream with full lightcurves'),
+            (3, 'kafka stream with lite lightcurve'),
+            (4, 'kafka stream with full alert'),
         )
         model = filter_query
         widgets = {

--- a/webserver/lasair/apps/filter_query/forms.py
+++ b/webserver/lasair/apps/filter_query/forms.py
@@ -109,7 +109,8 @@ class filterQueryForm(forms.ModelForm):
             (0, 'muted'),
             (1, 'email stream (daily)'),
             (2, 'kafka stream'),
-            (3, 'kafka stream with lightcurves'),
+            (3, 'kafka stream with lite lightcurves'),
+            (4, 'kafka stream with full lightcurves'),
         )
         model = filter_query
         widgets = {
@@ -198,7 +199,8 @@ class UpdateFilterQueryForm(forms.ModelForm):
             (0, 'muted'),
             (1, 'email stream (daily)'),
             (2, 'kafka stream'),
-            (3, 'kafka stream with lightcurves'),
+            (3, 'kafka stream with lite lightcurves'),
+            (4, 'kafka stream with full lightcurves'),
         )
         model = filter_query
         widgets = {
@@ -245,7 +247,8 @@ class DuplicateFilterQueryForm(forms.ModelForm):
             (0, 'muted'),
             (1, 'email stream (daily)'),
             (2, 'kafka stream'),
-            (3, 'kafka stream with lightcurves'),
+            (3, 'kafka stream with lite lightcurves'),
+            (4, 'kafka stream with full lightcurves'),
         )
         model = filter_query
         widgets = {

--- a/webserver/lasair/templates/includes/widgets/widget_filter_query_header.html
+++ b/webserver/lasair/templates/includes/widgets/widget_filter_query_header.html
@@ -66,7 +66,7 @@
                     {{filterQ.description}}
                 </small>
                 <small class="text-gray-500">
-                    The filter is <b>{% if not filterQ.active %}not active{% elif filterQ.active == 1%} streamed via email{% elif filterQ.active == 2%} streamed via kafka</b> with the topic name <code>{{filterQ.topic_name}}</code><b>{% endif %}.</b> {% include "includes/info_tooltip.html" with info="when active, a filter will be dynamically matched against new transient alerts and the results streamed via email or kafka" position="auto" link=docroot|add:"/core_functions/alert-streams.html#kafka-streams" %}
+                    The filter is <b>{% if not filterQ.active %}not active{% elif filterQ.active == 1%} streamed via email {% elif filterQ.active == 2%} streamed via kafka</b> with the topic name <code>{{filterQ.topic_name}}</code><b> {% elif filterQ.active == 3%} streamed via kafka with lite lightcurve</b> with the topic name <code>{{filterQ.topic_name}}</code><b> {% elif filterQ.active == 4%} streamed via kafka with full alert</b> with the topic name <code>{{filterQ.topic_name}}</code><b> {% endif %}.</b> {% include "includes/info_tooltip.html" with info="when active, a filter will be dynamically matched against new transient alerts and the results streamed via email or kafka" position="auto" link=docroot|add:"/core_functions/alert-streams.html#kafka-streams" %}
                 </small>
             </div>
 

--- a/webserver/lasair/templates/queryform.html
+++ b/webserver/lasair/templates/queryform.html
@@ -68,7 +68,9 @@ is_owner means 2.1
                                 This query is:<br/>
                                 &nbsp;&nbsp;&nbsp;<input type="radio" name="active" value="0" {% if myquery.active == 0 or new %}checked{% endif %}> Not a streaming filter<br/>
                                 &nbsp;&nbsp;&nbsp;<input type="radio" name="active" value="1" {% if myquery.active == 1 %}checked{% endif %}> Convert to filter and Email to {{ email }} (max once a day) and log <br/>
-                                &nbsp;&nbsp;&nbsp;<input type="radio" name="active" value="2" {% if myquery.active == 2 %}checked{% endif %}> Convert to Filter and produce Kafka and log <br/>
+                                &nbsp;&nbsp;&nbsp;<input type="radio" name="active" value="2" {% if myquery.active == 2 %}checked{% endif %}> Convert to Filter and produce Kafka <br/>
+                                &nbsp;&nbsp;&nbsp;<input type="radio" name="active" value="3" {% if myquery.active == 3 %}checked{% endif %}> Convert to Filter and produce Kafka and lite lightcurve <br/>
+                                &nbsp;&nbsp;&nbsp;<input type="radio" name="active" value="4" {% if myquery.active == 4 %}checked{% endif %}> Convert to Filter and produce Kafka and full alert <br/>
 
                                 A 'Filter' will run real time as alerts come in.
                                 Results can be sent, also in real time, via email or Kafka.


### PR DESCRIPTION
- Kafka output can now have lightcurve-lite info appended
- list of dict with keys: psfFlux, psfFluxErr, midpointMjdTai, band, reliability
- new setting when saving filter to have "kafka stream with lite lightcurve" 
- can also have "kafka stream with full alert"
- not available for email notification
<img width="383" height="146" alt="Screenshot 2026-01-28 at 12 54 34" src="https://github.com/user-attachments/assets/4d2c7450-cebd-4c45-b28f-94a864cd7aa2" />

