### PR TITLE
changed location of front_page_cache

### DIFF
--- a/deploy/roles/webserver/templates/settings.py.j2
+++ b/deploy/roles/webserver/templates/settings.py.j2
@@ -57,7 +57,7 @@ ACTIVE_EXPIRE = 180
 WATCHLIST_MAX            = 100000
 WATCHLIST_MAX_CROSSMATCH =  50000
 
-FRONT_PAGE_CACHE = LASAIR_ROOT + '/front_page_cache.json'
+FRONT_PAGE_CACHE = LASAIR_ROOT + '/lasair-lsst/webserver/static/files/front_page_cache.json'
 FRONT_PAGE_STALE = 1800
 ################################################################
 


### PR DESCRIPTION
I put the front_page_cache.json where it can be fetched from outside, for planetaria etc.

The URL is 
https://lasair-lsst-dev.lsst.ac.uk/lasair/static/files/front_page_cache.json
and will be
https://lasair.lsst.ac.uk/lasair/static/files/front_page_cache.json