### PR TITLE
Add/throttle fat kafka

### DIFF
--- a/common/schema/10_0/lasair_statistics.py
+++ b/common/schema/10_0/lasair_statistics.py
@@ -9,7 +9,7 @@ schema = {
     },
     {
       "name": "name",
-      "type": "text",
+      "type": "bigstring",
       "doc": "Which statistic"
     },
     {

--- a/common/schema/10_0/lasair_statistics.py
+++ b/common/schema/10_0/lasair_statistics.py
@@ -9,7 +9,7 @@ schema = {
     },
     {
       "name": "name",
-      "type": "string",
+      "type": "text",
       "doc": "Which statistic"
     },
     {

--- a/common/schema/prims.py
+++ b/common/schema/prims.py
@@ -20,7 +20,7 @@ def sql_type(primtype):
     elif primtype == 'bigint':   return ' bigint'          # 63 bit with sign
     elif primtype == 'date':     return ' datetime(6)'
     elif primtype == 'string':   return ' varchar(16)'
-    elif primtype == 'bigstring':return ' varchar(80)'
+    elif primtype == 'bigstring':return ' varchar(256)'
     elif primtype == 'text':     return ' text'
     elif primtype == 'timestamp':return ' timestamp'
     elif primtype == 'JSON':     return ' JSON'

--- a/common/src/topic_name.py
+++ b/common/src/topic_name.py
@@ -11,5 +11,7 @@ def topic_name(userid, name):
     # Make sure name is shorter than 128 characters
     if len(name) > 128:
         nname = name[0:64]+name[-64:]
+    else:
+        nname = name
     return 'lasair_' + str(userid) + nname
 

--- a/common/src/topic_name.py
+++ b/common/src/topic_name.py
@@ -8,5 +8,8 @@ def topic_name(userid, name):
 
     """
     name = ''.join(e for e in name if e.isalnum() or e == '_' or e == '-' or e == '.')
-    return 'lasair_' + str(userid) + name
+    # Make sure name is shorter than 128 characters
+    if len(name) > 128:
+        nname = name[0:64]+name[-64:]
+    return 'lasair_' + str(userid) + nname
 

--- a/deploy/common/settings.py.j2
+++ b/deploy/common/settings.py.j2
@@ -105,12 +105,6 @@ ANNOTATIONS_DUMP       = '/mnt/cephfs/lasair/annotations'
 CROSSMATCH_TNS_DUMP    = '/mnt/cephfs/lasair/crossmatch_tns'
 MYSQL_BACKUP_DIR       = '/mnt/cephfs/lasair/mysql_backup'
 
-# Fast annotations
-##################
-# Fast annotations cause immediate kafka output
-ANNOTATION_TOPIC       = 'lsst_annotations'
-ANNOTATION_GROUP_ID    = 'test004'
-
 # Webserver control
 ###################
 # Can have different web look and feel for different clusters

--- a/deploy/common/settings.py.j2
+++ b/deploy/common/settings.py.j2
@@ -53,6 +53,9 @@ WAIT_TIME              = 30
 SLACK_URL              = 'https://hooks.slack.com/services/{{ settings.slack_url_urlhook }}'
 SLACK_CHANNEL          = '{{ lasair_name }}'
 
+# Max bytes in public kafka for any filter per night
+MAX_KAFKA_BYTES_PER_FILTER = 100000000  # 100 Mbyte
+
 # Relational database mysql/galera
 ##################################
 DB_HOST                = '{{ db_host }}'

--- a/deploy/common/settings.py.j2
+++ b/deploy/common/settings.py.j2
@@ -53,9 +53,6 @@ WAIT_TIME              = 30
 SLACK_URL              = 'https://hooks.slack.com/services/{{ settings.slack_url_urlhook }}'
 SLACK_CHANNEL          = '{{ lasair_name }}'
 
-# Max bytes in public kafka for any filter per night
-MAX_KAFKA_BYTES_PER_FILTER = 100000000  # 100 Mbyte
-
 # Relational database mysql/galera
 ##################################
 DB_HOST                = '{{ db_host }}'

--- a/deploy/database.yaml
+++ b/deploy/database.yaml
@@ -299,7 +299,7 @@
   vars_files:
     - settings.yaml
   vars:
-    schema: "9_0"
+    schema: "10_0"
   tasks:
     - name: Create SQL files
       ansible.builtin.shell:

--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -163,7 +163,7 @@
     - settings.yaml
     - exports.yaml
   vars:
-    schema: "9_0"
+    schema: "10_0"
     db_host: "{{ (groups['db'] + groups['cluster_control'] + [''])[0] }}"
     db_port: "{% if groups['db'] %}3306{% else %}9001{% endif %}"
     mysql_root_password: "{{ settings.local_db_root_password }}"

--- a/deploy/roles/webserver/templates/settings.py.j2
+++ b/deploy/roles/webserver/templates/settings.py.j2
@@ -34,6 +34,9 @@ DB_PORT        = {{ db_port }}
 PUBLIC_KAFKA_PRODUCER   = 'kafka-pub:29092'
 PUBLIC_KAFKA_PASSWORD   = '{{ settings.kafka_password }}'
 
+# Quota per filter per day
+KAFKA_BYTE_QUOTA       = 100000000  # 100 Mbyte
+
 INTERNAL_KAFKA_PRODUCER = '{{ settings.kafka_producer }}:9092'
 ANNOTATION_TOPIC_OUT    = 'lsst_annotations'
 

--- a/pipeline/filter/filtercore.py
+++ b/pipeline/filter/filtercore.py
@@ -634,12 +634,12 @@ class Filter:
                 self.log.error("ERROR in filter/filters")
 
             # run the annotation queries
-            self.log.info('ANNOTATION FILTERS start %s' % now())
-            ntotal = filters.fast_anotation_filters(self)
-            if ntotal is not None:
-                self.log.info('ANNOTATION FILTERS got %d' % ntotal)
-            else:
-                self.log.error("ERROR in filter/fast_annotation_filters")
+#            self.log.info('ANNOTATION FILTERS start %s' % now())
+#            ntotal = filters.fast_annotation_filters(self)
+#            if ntotal is not None:
+#                self.log.info('ANNOTATION FILTERS got %d' % ntotal)
+#            else:
+#                self.log.error("ERROR in filter/fast_annotation_filters")
 
             # build CSV file with local database and transfer to main
             if self.transfer:

--- a/pipeline/filter/filtercore.py
+++ b/pipeline/filter/filtercore.py
@@ -633,14 +633,6 @@ class Filter:
             else:
                 self.log.error("ERROR in filter/filters")
 
-            # run the annotation queries
-#            self.log.info('ANNOTATION FILTERS start %s' % now())
-#            ntotal = filters.fast_annotation_filters(self)
-#            if ntotal is not None:
-#                self.log.info('ANNOTATION FILTERS got %d' % ntotal)
-#            else:
-#                self.log.error("ERROR in filter/fast_annotation_filters")
-
             # build CSV file with local database and transfer to main
             if self.transfer:
                 timers['ftransfer'].on()

--- a/pipeline/filter/filtercore.py
+++ b/pipeline/filter/filtercore.py
@@ -99,6 +99,7 @@ class Filter:
         self.alert_dict = {}
 
         self.consumer = None
+        self.producer = None
         self.database = None
 
         self.log = log or lasairLogging.getLogger("filter")
@@ -116,6 +117,10 @@ class Filter:
         # set up the Kafka consumer now
         if not self.consumer:
             self.consumer = self.make_kafka_consumer()
+
+        # set up the Kafka producer now
+        if not self.producer:
+            self.producer = self.make_kafka_producer()
 
         # set up the link to the local database
         if not self.database or not self.database.is_connected():
@@ -195,7 +200,26 @@ class Filter:
             consumer.subscribe([self.topic_in])
             return consumer
         except Exception as e:
-            self.log.error('ERROR cannot connect to kafka' + str(e))
+            self.log.error('ERROR cannot make kafka consumer' + str(e))
+
+    def make_kafka_producer(self):
+        """ Make a kafka producer.
+        """
+        conf = {
+            'bootstrap.servers': settings.PUBLIC_KAFKA_SERVER,
+            'security.protocol': 'SASL_PLAINTEXT',
+            'sasl.mechanisms': 'SCRAM-SHA-256',
+            'sasl.username': settings.PUBLIC_KAFKA_USERNAME,
+            'sasl.password': settings.PUBLIC_KAFKA_PASSWORD
+        }
+
+        self.log.info(str(conf))
+        self.log.info('Topic in = %s' % self.topic_in)
+        try:
+            producer = confluent_kafka.Producer(conf)
+            return producer
+        except Exception as e:
+            self.log.error('ERROR cannot make kafka producer' + str(e))
 
     @staticmethod
     def create_insert_sherlock(ann: dict):

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -340,6 +340,8 @@ def crap_converter(o):
 # used by json encoder when it gets a type it doesn't understand
     if isinstance(o, datetime.datetime) or type(o).__module__ == 'numpy':
         return o.__str__()
+    else:
+        return 'Unexpected type in json.dumps:' + str(type(o))
 
 def kafka_ack(err, msg):
     if err is not None:

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -313,6 +313,7 @@ def dispose_kafka(query_results, query, ms, nid):
     try:
         p = Producer(conf)
         for out in query_results: 
+            out.pop('annotations', None)   # extra Lasair stuff
             jsonout = json.dumps(out, default=datetime_converter)
             nbytes += len(jsonout)
             nalert += 1

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -4,26 +4,26 @@ Fetch them from database, construct SQL, execute, produce kafka
 (1) fetch_queries(msl_remote, ms, nid) 
 gets all the queries from the remote database. ms is manage_status and nid is today.
 
-(3) run_queries(batch, query_list, ms, nid):
+(2) run_queries(batch, query_list, ms, nid):
 Uses query_list runs all the queries against local database
 
-(5) run_query(query, msl, fltr)
+(3) run_query(query, msl, fltr)
 Run a specific query and return query_results
 
-(6) dispose_query_results(query, query_results, fltr, ms, nid)
+(4) dispose_query_results(query, query_results, fltr, ms, nid)
 Deal with the query results
 
-(6a) fetch_digest(topic_name):
+(4a) fetch_digest(topic_name):
     Get the digest file from shared storage
 
-(6b) dispose_email(allrecords, last_email, query):
+(4b) dispose_email(allrecords, last_email, query):
     Deal with outgoing emails, it calls this to actually send
     send_email(email, topic, message, message_html):
 
-(6c) dispose_kafka(query_results, query, ms, nid):
+(4c) dispose_kafka(query_results, query, ms, nid):
     Produce Kafka output to public stream
 
-(6d) write_digest(allrecords, topic_name, last_email):
+(4d) write_digest(allrecords, topic_name, last_email):
     Write the digest file for this topic
 
 """
@@ -60,6 +60,7 @@ def fetch_queries(msl_remote, ms, nid):
             'tables':    query['tables'],
             'real_sql':  query['real_sql'],
             'topic_name':query['topic_name'],
+            'byte_quota':query['byte_quota'],
         }
         # Lets see if some kafka has produced on this filter
         nbytesname = query['topic_name'] + '_bytes_produced'
@@ -297,7 +298,8 @@ def dispose_kafka(query_results, query, ms, nid):
     topic_name = query['topic_name']
     # First decide if this filter has already produced enough
     bp = query.get('bytes_produced', 0)
-    will_produce = (bp < settings.MAX_KAFKA_BYTES_PER_FILTER)
+    bq = query.get('byte_quota', settings.MAX_KAFKA_BYTES_PER_FILTER)
+    will_produce = (bp < bq)
 
     # Kafka produce config
     conf = {

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -45,7 +45,7 @@ def fetch_queries(msl_remote, ms, nid):
 
     # Fetch all the stored queries from the main database
     cursor = msl_remote.cursor(buffered=True, dictionary=True)
-    query = 'SELECT mq_id, user, name, email, tables, active, real_sql, topic_name '
+    query = 'SELECT mq_id, user, name, email, tables, active, byte_quota, real_sql, topic_name '
     query += 'FROM myqueries, auth_user WHERE myqueries.user = auth_user.id AND active > 0'
     cursor.execute(query)
 

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -127,6 +127,7 @@ def run_query(query, msl):
                  "and write to lasair-help@roe.ac.uk if you want help." % (utc, topic, str(e)))
         print(error)
         print(sqlquery_real)
+        send_email(email, topic, error)
         return []
 
     return query_results

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -181,6 +181,7 @@ def dispose_query_results(query, query_results, fltr, ms, nid):
                     except:
                         fltr.log.error(f'ERROR in filter/dispose_query_results {diaObjectId} not found in alert_dict')
             if active == 4:   # append full alert
+
                 for q in query_results:
                     try:
                         diaObjectId = q['diaObjectId']
@@ -200,7 +201,7 @@ def write_digest(allrecords, topic_name, last_entry, last_email):
             'last_email': last_email_text, 
             'digest': allrecords
             }
-    digestdict_text = json.dumps(digest_dict, indent=2, default=datetime_converter)
+    digestdict_text = json.dumps(digest_dict, indent=2, default=crap_converter)
 
     filename = settings.KAFKA_STREAMS + '/' + topic_name
     f = open(filename, 'w')
@@ -255,7 +256,7 @@ def dispose_email(allrecords, last_email, query, force=False):
                 message += diaObjectId + '\n'
                 message_html += '<a href="%s/objects/%s/">%s</a><br/> \n' % (settings.LASAIR_URL, diaObjectId, diaObjectId)
             else:
-                jsonout = json.dumps(out, default=datetime_converter)
+                jsonout = json.dumps(out, default=crap_converter)
                 message += jsonout + '\n'
     try:
         send_email(query['email'], topic, message, message_html)
@@ -313,8 +314,9 @@ def dispose_kafka(query_results, query, ms, nid):
     try:
         p = Producer(conf)
         for out in query_results: 
-            out.pop('annotations', None)   # extra Lasair stuff
-            jsonout = json.dumps(out, default=datetime_converter)
+            if 'alert' in out:
+                out['alert'].pop('annotations', None)   # extra Lasair stuff
+            jsonout = json.dumps(out, default=crap_converter)
             nbytes += len(jsonout)
             nalert += 1
             if will_produce:
@@ -339,16 +341,15 @@ def dispose_kafka(query_results, query, ms, nid):
             topic_name+'_alerts_rejected': nalert,
         }, nid)
 
-def datetime_converter(o):
-    """datetime_converter.
+def crap_converter(o):
+    """crap_converter.
 
     Args:
         o:
     """
 # used by json encoder when it gets a type it doesn't understand
-    if isinstance(o, datetime.datetime):
+    if isinstance(o, datetime.datetime) or type(o).__module__ == 'numpy':
         return o.__str__()
-
 
 def kafka_ack(err, msg):
     if err is not None:

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -1,24 +1,16 @@
 """ Runs the user's queries. 
 Fetch them from database, construct SQL, execute, produce kafka
 
-(1) fetch_queries(): 
-gets all the queries from the database
+(1) fetch_queries(msl_remote, ms, nid) 
+gets all the queries from the remote database. ms is manage_status and nid is today.
 
-# (2) run_annotation_queries(query_list): 
-# may be called to get all the recent fast annotations 
+(3) run_queries(batch, query_list, ms, nid):
+Uses query_list runs all the queries against local database
 
-(3) run_queries(batch, query_list, annotation_list=None):
-Uses query_list and possibly annotation_list and runs all the queries against 
-local, 
-# or those involving annotator against main databaase
-
-# (4) query_for_object(query, diaObjectId):
-# If doing fast annotations, convert a given query with specific diaObjectId
-
-(5) run_query(query, msl, annotator=None, diaObjectId=None):
+(5) run_query(query, msl, fltr)
 Run a specific query and return query_results
 
-(6) dispose_query_results(query, query_results):
+(6) dispose_query_results(query, query_results, fltr, ms, nid)
 Deal with the query results
 
 (6a) fetch_digest(topic_name):
@@ -28,7 +20,7 @@ Deal with the query results
     Deal with outgoing emails, it calls this to actually send
     send_email(email, topic, message, message_html):
 
-(6c) dispose_kafka(query_results, topic):
+(6c) dispose_kafka(query_results, query, ms, nid):
     Produce Kafka output to public stream
 
 (6d) write_digest(allrecords, topic_name, last_email):
@@ -78,7 +70,7 @@ def fetch_queries(msl_remote, ms, nid):
         query_list.append(query_dict)
     return query_list
 
-def run_queries(fltr, query_list, annotation_list=None, ms=None, nid=None):
+def run_queries(fltr, query_list, ms, nid):
     """
     When annotation_list is None, it runs all the queries against the local database
     When not None, runs some queires agains a specific object, using the main database
@@ -88,59 +80,23 @@ def run_queries(fltr, query_list, annotation_list=None, ms=None, nid=None):
     for query in query_list:
         n = 0
         t = time.time()
-
-        # normal case of streaming queries
-        if annotation_list is None:
-            query_results = run_query(query, fltr.database, fltr=fltr)
-            n += dispose_query_results(query, query_results, fltr, ms, nid)
-
-        # immediate response to active=2 annotators
-#        else:
-#            for ann in annotation_list:  
-#                # msl_remote = db_connect.remote()
-#                query_results = run_query(query, fltr.database,
-#                                          ann['annotator'], ann['diaObjectId'], fltr=fltr)
-#                print('fast annotator %s on object %s' % (ann['annotator'], ann['diaObjectId']))
-#                print('results:', query_results)
-#                n += dispose_query_results(query, query_results, fltr, ms, nid)
-
+        query_results = run_query(query, fltr.database, fltr)
+        n += dispose_query_results(query, query_results, fltr, ms, nid)
         t = time.time() - t
         if n > 0:
-            print('   %s got %d in %.1f seconds' % (query['topic_name'], n, t))
+            print('   %s(%d) got %d in %.1f seconds' % (query['topic_name'], query['active'], n, t))
             sys.stdout.flush()
         ntotal += n
     return ntotal
 
-
-#def query_for_object(query, diaObjectId):
-#    """ modifies an existing query to add a new constraint for a specific object.
-#    We already know this query comes from multiple tables: objects and annotators,
-#    so we know there is an existing WHERE clause. Can add the new constraint to the end,
-#    unless there is an ORDER BY, in which case it comes before that.
-#
-#    Args:
-#        query: the original query, as generated from the Lasair query builder
-#        diaObjectId: the object that is the new constraint
-#    """
-#    tok = query.replace('order by', 'ORDER BY').split('ORDER BY')
-#    query = tok[0] + (' AND objects.diaObjectId=%s ' % str(diaObjectId))
-#    if len(tok) == 2: # has order clause, add it back
-#        query += ' ORDER BY ' + tok[1]
-#    return query
-#
-
-def run_query(query, msl, annotator=None, diaObjectId=None, fltr=None):
-    """run_query. Two cases here: 
-    if annotator=None, runs the query against the local database
-    if annotator and diaObjectId, checks if the query involves the annotator, 
-        and if so, runs the query for the given object on main database
+def run_query(query, msl, fltr):
+    """run_query.
+        runs the query against the local database
 
     Args:
         query:
         msl:
         fltr:
-        diaObjectId:
-        annotator:
     """
     active = query['active']
     email = query['email']
@@ -148,12 +104,6 @@ def run_query(query, msl, annotator=None, diaObjectId=None, fltr=None):
     limit = 1000
 
     sqlquery_real = query['real_sql']
-#    if annotator:
-#        # if the annotator does not appear in the query tables, then we don't need to run it
-#        if query['tables'] not in annotator:
-#            return []
-#        # run the query against main for this specific object that has been annotated
-#        sqlquery_real = query_for_object(sqlquery_real, diaObjectId)
 
     # in any case, 10 second timeout and limit the output
     sqlquery_real = ('SET STATEMENT max_statement_time=%d FOR %s LIMIT %d' %
@@ -177,8 +127,8 @@ def run_query(query, msl, annotator=None, diaObjectId=None, fltr=None):
                  "and write to lasair-help@roe.ac.uk if you want help." % (utc, topic, str(e)))
         print(error)
         print(sqlquery_real)
-        if not fltr or fltr.send_email:
-            send_email(email, topic, error)
+#        if fltr.send_email:
+#            send_email(email, topic, error)
         return []
 
     return query_results
@@ -205,7 +155,7 @@ def lightcurve_lite(alert):
         "diaForcedSourcesList": diaForcedSourcesList,
     }
 
-def dispose_query_results(query, query_results, fltr=None, ms=None, nid=None):
+def dispose_query_results(query, query_results, fltr, ms, nid):
     """ Send out the query results by email or kafka, and ipdate the digest file
     """
     if len(query_results) == 0:
@@ -216,14 +166,14 @@ def dispose_query_results(query, query_results, fltr=None, ms=None, nid=None):
         # send results by email if 24 hours has passed, returns time of last email send
         digest, last_entry, last_email = fetch_digest(query['topic_name'])
         allrecords = (query_results + digest)[:10000]
-        if not fltr or fltr.send_email:
+        if fltr.send_email:
             last_email = dispose_email(allrecords, last_email, query)
         utcnow = datetime.datetime.now(datetime.UTC)
         write_digest(allrecords, query['topic_name'], utcnow, last_email)
 
-    if active > 2:
+    if active >= 2:
         # send results by kafka on given topic
-        if not fltr or fltr.send_kafka:
+        if fltr.send_kafka:
             if active == 3:   # append lightcurve lite
                 for q in query_results:
                     try:
@@ -238,7 +188,7 @@ def dispose_query_results(query, query_results, fltr=None, ms=None, nid=None):
                         q['alert'] = fltr.alert_dict[diaObjectId]
                     except:
                         pass
-            dispose_kafka(query_results, query, ms, nid)
+        dispose_kafka(query_results, query, ms, nid)
 
     return len(query_results)
 
@@ -418,47 +368,8 @@ def filters(fltr):
         fltr.log.error("ERROR in filter/run_active_queries.fetch_queries" + str(e))
         return None
 
-    if 1:
-        ntotal = run_queries(fltr, query_list, annotation_list=None, ms=ms, nid=nid)
-        return ntotal
-#    except Exception as e:
-#        fltr.log.error("ERROR in filter/run_active_queries.run_queries" + str(e))
-#        return None
-
-
-#def fast_annotation_filters(fltr):
-#    """run_annotation_queries.
-#    Pulls the recent content from the kafka topic 'lsst_annotations' 
-#    Each message has an annotator/topic name, and the diaObjectId that was annotated.
-#    Queries that have that annotator should run against that object
-#    """
-#    try:
-#        query_list = fetch_queries()
-#    except Exception as e:
-#        fltr.log.error("ERROR in filter/run_active_queries.fetch_queries" + str(e))
-#        return None
-#
-#    annotation_list = []
-#    conf = {
-#        'bootstrap.servers':   settings.KAFKA_SERVER,
-#        'group.id':            settings.ANNOTATION_GROUP_ID,
-#        'default.topic.config': {'auto.offset.reset': 'earliest'}
-#    }
-#    streamReader = Consumer(conf)
-#    topic = settings.ANNOTATION_TOPIC
-#    streamReader.subscribe([topic])
-#    while 1:
-#        msg = streamReader.poll(timeout=5)
-#        if msg == None: break
-#        try:
-#            ann = json.loads(msg.value())
-#            annotation_list.append(ann)
-#        except:
-#            continue
-#    streamReader.close()
-#    ntotal = run_queries(fltr, query_list, annotation_list)
-#    return ntotal
-
+    ntotal = run_queries(fltr, query_list, ms=ms, nid=nid)
+    return ntotal
 
 # if __name__ == "__main__":
 #     from src import slack_webhook

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -7,7 +7,7 @@ gets all the queries from the remote database. ms is manage_status and nid is to
 (2) run_queries(batch, query_list, ms, nid):
 Uses query_list runs all the queries against local database
 
-(3) run_query(query, msl, fltr)
+(3) run_query(query, msl)
 Run a specific query and return query_results
 
 (4) dispose_query_results(query, query_results, fltr, ms, nid)
@@ -81,7 +81,7 @@ def run_queries(fltr, query_list, ms, nid):
     for query in query_list:
         n = 0
         t = time.time()
-        query_results = run_query(query, fltr.database, fltr)
+        query_results = run_query(query, fltr.database)
         n += dispose_query_results(query, query_results, fltr, ms, nid)
         t = time.time() - t
         if n > 0:
@@ -90,14 +90,13 @@ def run_queries(fltr, query_list, ms, nid):
         ntotal += n
     return ntotal
 
-def run_query(query, msl, fltr):
+def run_query(query, msl):
     """run_query.
         runs the query against the local database
 
     Args:
         query:
         msl:
-        fltr:
     """
     active = query['active']
     email = query['email']
@@ -128,8 +127,6 @@ def run_query(query, msl, fltr):
                  "and write to lasair-help@roe.ac.uk if you want help." % (utc, topic, str(e)))
         print(error)
         print(sqlquery_real)
-#        if fltr.send_email:
-#            send_email(email, topic, error)
         return []
 
     return query_results

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -296,7 +296,7 @@ def dispose_kafka(query_results, query, ms, nid):
     topic_name = query['topic_name']
     # First decide if this filter has already produced enough
     bp = query.get('bytes_produced', 0)
-    bq = query.get('byte_quota', settings.MAX_KAFKA_BYTES_PER_FILTER)
+    bq = query['byte_quota']
     will_produce = (bp < bq)
 
     # Kafka produce config

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -179,14 +179,14 @@ def dispose_query_results(query, query_results, fltr, ms, nid):
                         diaObjectId = q['diaObjectId']
                         q['alert'] = lightcurve_lite(fltr.alert_dict[diaObjectId])
                     except:
-                        pass
+                        fltr.log.error(f'ERROR in filter/dispose_query_results {diaObjectId} not found in alert_dict')
             if active == 4:   # append full alert
                 for q in query_results:
                     try:
                         diaObjectId = q['diaObjectId']
                         q['alert'] = fltr.alert_dict[diaObjectId]
                     except:
-                        pass
+                        fltr.log.error(f'ERROR in filter/dispose_query_results {diaObjectId} not found in alert_dict')
         dispose_kafka(query_results, query, ms, nid)
 
     return len(query_results)

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -4,15 +4,16 @@ Fetch them from database, construct SQL, execute, produce kafka
 (1) fetch_queries(): 
 gets all the queries from the database
 
-(2) run_annotation_queries(query_list): 
-may be called to get all the recent fast annotations 
+# (2) run_annotation_queries(query_list): 
+# may be called to get all the recent fast annotations 
 
 (3) run_queries(batch, query_list, annotation_list=None):
 Uses query_list and possibly annotation_list and runs all the queries against 
-local, or those involving annotator against main databaase
+local, 
+# or those involving annotator against main databaase
 
-(4) query_for_object(query, diaObjectId):
-If doing fast annotations, convert a given query with specific diaObjectId
+# (4) query_for_object(query, diaObjectId):
+# If doing fast annotations, convert a given query with specific diaObjectId
 
 (5) run_query(query, msl, annotator=None, diaObjectId=None):
 Run a specific query and return query_results
@@ -42,15 +43,13 @@ from email.mime.text import MIMEText
 
 sys.path.append('../../common')
 import settings
-from src import db_connect
+from src import db_connect, manage_status, date_nid
 
 
-def fetch_queries():
+def fetch_queries(msl_remote, ms, nid):
     """fetch_queries.
     Get all the stored queries from the main database
     """
-    # first get the user queries from the database that the webserver uses
-    msl_remote = db_connect.remote()
 
     # Fetch all the stored queries from the main database
     cursor = msl_remote.cursor(buffered=True, dictionary=True)
@@ -70,11 +69,16 @@ def fetch_queries():
             'real_sql':  query['real_sql'],
             'topic_name':query['topic_name'],
         }
+        # Lets see if some kafka has produced on this filter
+        nbytesname = query['topic_name'] + '_bytes_produced'
+        status = ms.read(nid)
+        if nbytesname in status:
+            query_dict['bytes_produced'] = status[nbytesname]
+
         query_list.append(query_dict)
     return query_list
 
-
-def run_queries(fltr, query_list, annotation_list=None):
+def run_queries(fltr, query_list, annotation_list=None, ms=None, nid=None):
     """
     When annotation_list is None, it runs all the queries against the local database
     When not None, runs some queires agains a specific object, using the main database
@@ -88,17 +92,17 @@ def run_queries(fltr, query_list, annotation_list=None):
         # normal case of streaming queries
         if annotation_list is None:
             query_results = run_query(query, fltr.database, fltr=fltr)
-            n += dispose_query_results(query, query_results, fltr)
+            n += dispose_query_results(query, query_results, fltr, ms, nid)
 
         # immediate response to active=2 annotators
-        else:
-            for ann in annotation_list:  
-                # msl_remote = db_connect.remote()
-                query_results = run_query(query, fltr.database,
-                                          ann['annotator'], ann['diaObjectId'], fltr=fltr)
-                print('fast annotator %s on object %s' % (ann['annotator'], ann['diaObjectId']))
-                print('results:', query_results)
-                n += dispose_query_results(query, query_results, fltr)
+#        else:
+#            for ann in annotation_list:  
+#                # msl_remote = db_connect.remote()
+#                query_results = run_query(query, fltr.database,
+#                                          ann['annotator'], ann['diaObjectId'], fltr=fltr)
+#                print('fast annotator %s on object %s' % (ann['annotator'], ann['diaObjectId']))
+#                print('results:', query_results)
+#                n += dispose_query_results(query, query_results, fltr, ms, nid)
 
         t = time.time() - t
         if n > 0:
@@ -108,22 +112,22 @@ def run_queries(fltr, query_list, annotation_list=None):
     return ntotal
 
 
-def query_for_object(query, diaObjectId):
-    """ modifies an existing query to add a new constraint for a specific object.
-    We already know this query comes from multiple tables: objects and annotators,
-    so we know there is an existing WHERE clause. Can add the new constraint to the end,
-    unless there is an ORDER BY, in which case it comes before that.
-
-    Args:
-        query: the original query, as generated from the Lasair query builder
-        diaObjectId: the object that is the new constraint
-    """
-    tok = query.replace('order by', 'ORDER BY').split('ORDER BY')
-    query = tok[0] + (' AND objects.diaObjectId=%s ' % str(diaObjectId))
-    if len(tok) == 2: # has order clause, add it back
-        query += ' ORDER BY ' + tok[1]
-    return query
-
+#def query_for_object(query, diaObjectId):
+#    """ modifies an existing query to add a new constraint for a specific object.
+#    We already know this query comes from multiple tables: objects and annotators,
+#    so we know there is an existing WHERE clause. Can add the new constraint to the end,
+#    unless there is an ORDER BY, in which case it comes before that.
+#
+#    Args:
+#        query: the original query, as generated from the Lasair query builder
+#        diaObjectId: the object that is the new constraint
+#    """
+#    tok = query.replace('order by', 'ORDER BY').split('ORDER BY')
+#    query = tok[0] + (' AND objects.diaObjectId=%s ' % str(diaObjectId))
+#    if len(tok) == 2: # has order clause, add it back
+#        query += ' ORDER BY ' + tok[1]
+#    return query
+#
 
 def run_query(query, msl, annotator=None, diaObjectId=None, fltr=None):
     """run_query. Two cases here: 
@@ -144,12 +148,12 @@ def run_query(query, msl, annotator=None, diaObjectId=None, fltr=None):
     limit = 1000
 
     sqlquery_real = query['real_sql']
-    if annotator:
-        # if the annotator does not appear in the query tables, then we don't need to run it
-        if query['tables'] not in annotator:
-            return []
-        # run the query against main for this specific object that has been annotated
-        sqlquery_real = query_for_object(sqlquery_real, diaObjectId)
+#    if annotator:
+#        # if the annotator does not appear in the query tables, then we don't need to run it
+#        if query['tables'] not in annotator:
+#            return []
+#        # run the query against main for this specific object that has been annotated
+#        sqlquery_real = query_for_object(sqlquery_real, diaObjectId)
 
     # in any case, 10 second timeout and limit the output
     sqlquery_real = ('SET STATEMENT max_statement_time=%d FOR %s LIMIT %d' %
@@ -201,19 +205,21 @@ def lightcurve_lite(alert):
         "diaForcedSourcesList": diaForcedSourcesList,
     }
 
-def dispose_query_results(query, query_results, fltr=None):
+def dispose_query_results(query, query_results, fltr=None, ms=None, nid=None):
     """ Send out the query results by email or kafka, and ipdate the digest file
     """
     if len(query_results) == 0:
         return 0
     active = query['active']
-    digest, last_entry, last_email = fetch_digest(query['topic_name'])
-    allrecords = (query_results + digest)[:10000]
 
     if active == 1:
         # send results by email if 24 hours has passed, returns time of last email send
+        digest, last_entry, last_email = fetch_digest(query['topic_name'])
+        allrecords = (query_results + digest)[:10000]
         if not fltr or fltr.send_email:
             last_email = dispose_email(allrecords, last_email, query)
+        utcnow = datetime.datetime.now(datetime.UTC)
+        write_digest(allrecords, query['topic_name'], utcnow, last_email)
 
     if active > 2:
         # send results by kafka on given topic
@@ -232,12 +238,9 @@ def dispose_query_results(query, query_results, fltr=None):
                         q['alert'] = fltr.alert_dict[diaObjectId]
                     except:
                         pass
-            dispose_kafka(query_results, query['topic_name'])
+            dispose_kafka(query_results, query, ms, nid)
 
-    utcnow = datetime.datetime.now(datetime.UTC)
-    write_digest(allrecords, query['topic_name'], utcnow, last_email)
     return len(query_results)
-
 
 def write_digest(allrecords, topic_name, last_entry, last_email):
     # update the digest file
@@ -338,9 +341,15 @@ def send_email(email, topic, message, message_html=''):
     s.quit()
 
 
-def dispose_kafka(query_results, topic):
+def dispose_kafka(query_results, query, ms, nid):
     """ Send out query results by kafka to the given topic.
     """
+    topic_name = query['topic_name']
+    # First decide if this filter has already produced enough
+    bp = query.get('bytes_produced', 0)
+    will_produce = (bp < settings.MAX_KAFKA_BYTES_PER_FILTER)
+
+    # Kafka produce config
     conf = {
         'bootstrap.servers': settings.PUBLIC_KAFKA_SERVER,
         'security.protocol': 'SASL_PLAINTEXT',
@@ -349,11 +358,16 @@ def dispose_kafka(query_results, topic):
         'sasl.password': settings.PUBLIC_KAFKA_PASSWORD
     }
 
+    nbytes = 0
+    nalert = 0
     try:
         p = Producer(conf)
         for out in query_results: 
             jsonout = json.dumps(out, default=datetime_converter)
-            p.produce(topic, value=jsonout, callback=kafka_ack)
+            nbytes += len(jsonout)
+            nalert += 1
+            if will_produce:
+                p.produce(topic_name, value=jsonout, callback=kafka_ack)
         p.flush(10.0)   # 10 second timeout
     except Exception as e:
         rtxt = "ERROR in filter/run_active_queries: cannot produce to public kafka"
@@ -362,6 +376,17 @@ def dispose_kafka(query_results, topic):
         print(rtxt)
         sys.stdout.flush()
 
+    # Record this as produced or rejected
+    if will_produce:
+        ms.add({
+            topic_name+'_bytes_produced' : nbytes,
+            topic_name+'_alerts_produced': nalert,
+        }, nid)
+    else:
+        ms.add({
+            topic_name+'_bytes_rejected' : nbytes,
+            topic_name+'_alerts_rejected': nalert,
+        }, nid)
 
 def datetime_converter(o):
     """datetime_converter.
@@ -380,52 +405,59 @@ def kafka_ack(err, msg):
 
 
 def filters(fltr):
+    # first get the user queries from the database that the webserver uses
+    msl_remote = db_connect.remote()
+
+    # how many bytes has each filter already produced
+    ms = manage_status.manage_status(msl=msl_remote)
+    nid = date_nid.nid_now()
+
     try:
-        query_list = fetch_queries()
+        query_list = fetch_queries(msl_remote, ms, nid)
     except Exception as e:
         fltr.log.error("ERROR in filter/run_active_queries.fetch_queries" + str(e))
         return None
 
     if 1:
-        ntotal = run_queries(fltr, query_list)
+        ntotal = run_queries(fltr, query_list, annotation_list=None, ms=ms, nid=nid)
         return ntotal
 #    except Exception as e:
 #        fltr.log.error("ERROR in filter/run_active_queries.run_queries" + str(e))
 #        return None
 
 
-def fast_anotation_filters(fltr):
-    """run_annotation_queries.
-    Pulls the recent content from the kafka topic 'lsst_annotations' 
-    Each message has an annotator/topic name, and the diaObjectId that was annotated.
-    Queries that have that annotator should run against that object
-    """
-    try:
-        query_list = fetch_queries()
-    except Exception as e:
-        fltr.log.error("ERROR in filter/run_active_queries.fetch_queries" + str(e))
-        return None
-
-    annotation_list = []
-    conf = {
-        'bootstrap.servers':   settings.KAFKA_SERVER,
-        'group.id':            settings.ANNOTATION_GROUP_ID,
-        'default.topic.config': {'auto.offset.reset': 'earliest'}
-    }
-    streamReader = Consumer(conf)
-    topic = settings.ANNOTATION_TOPIC
-    streamReader.subscribe([topic])
-    while 1:
-        msg = streamReader.poll(timeout=5)
-        if msg == None: break
-        try:
-            ann = json.loads(msg.value())
-            annotation_list.append(ann)
-        except:
-            continue
-    streamReader.close()
-    ntotal = run_queries(fltr, query_list, annotation_list)
-    return ntotal
+#def fast_annotation_filters(fltr):
+#    """run_annotation_queries.
+#    Pulls the recent content from the kafka topic 'lsst_annotations' 
+#    Each message has an annotator/topic name, and the diaObjectId that was annotated.
+#    Queries that have that annotator should run against that object
+#    """
+#    try:
+#        query_list = fetch_queries()
+#    except Exception as e:
+#        fltr.log.error("ERROR in filter/run_active_queries.fetch_queries" + str(e))
+#        return None
+#
+#    annotation_list = []
+#    conf = {
+#        'bootstrap.servers':   settings.KAFKA_SERVER,
+#        'group.id':            settings.ANNOTATION_GROUP_ID,
+#        'default.topic.config': {'auto.offset.reset': 'earliest'}
+#    }
+#    streamReader = Consumer(conf)
+#    topic = settings.ANNOTATION_TOPIC
+#    streamReader.subscribe([topic])
+#    while 1:
+#        msg = streamReader.poll(timeout=5)
+#        if msg == None: break
+#        try:
+#            ann = json.loads(msg.value())
+#            annotation_list.append(ann)
+#        except:
+#            continue
+#    streamReader.close()
+#    ntotal = run_queries(fltr, query_list, annotation_list)
+#    return ntotal
 
 
 # if __name__ == "__main__":

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -188,7 +188,7 @@ def dispose_query_results(query, query_results, fltr, ms, nid):
                         q['alert'] = fltr.alert_dict[diaObjectId]
                     except:
                         fltr.log.error(f'ERROR in filter/dispose_query_results {diaObjectId} not found in alert_dict')
-        dispose_kafka(query_results, query, ms, nid)
+        dispose_kafka(fltr.producer, query_results, query, ms, nid)
 
     return len(query_results)
 
@@ -291,7 +291,7 @@ def send_email(email, topic, message, message_html=''):
     s.quit()
 
 
-def dispose_kafka(query_results, query, ms, nid):
+def dispose_kafka(producer, query_results, query, ms, nid):
     """ Send out query results by kafka to the given topic.
     """
     topic_name = query['topic_name']
@@ -300,19 +300,9 @@ def dispose_kafka(query_results, query, ms, nid):
     bq = query['byte_quota']
     will_produce = (bp < bq)
 
-    # Kafka produce config
-    conf = {
-        'bootstrap.servers': settings.PUBLIC_KAFKA_SERVER,
-        'security.protocol': 'SASL_PLAINTEXT',
-        'sasl.mechanisms': 'SCRAM-SHA-256',
-        'sasl.username': settings.PUBLIC_KAFKA_USERNAME,
-        'sasl.password': settings.PUBLIC_KAFKA_PASSWORD
-    }
-
     nbytes = 0
     nalert = 0
     try:
-        p = Producer(conf)
         for out in query_results: 
             if 'alert' in out:
                 out['alert'].pop('annotations', None)   # extra Lasair stuff
@@ -320,8 +310,8 @@ def dispose_kafka(query_results, query, ms, nid):
             nbytes += len(jsonout)
             nalert += 1
             if will_produce:
-                p.produce(topic_name, value=jsonout, callback=kafka_ack)
-        p.flush(10.0)   # 10 second timeout
+                producer.produce(topic_name, value=jsonout, callback=kafka_ack)
+        producer.flush(10.0)   # 10 second timeout
     except Exception as e:
         rtxt = "ERROR in filter/run_active_queries: cannot produce to public kafka"
         rtxt += str(e)
@@ -342,7 +332,7 @@ def dispose_kafka(query_results, query, ms, nid):
         }, nid)
 
 def crap_converter(o):
-    """crap_converter.
+    """crap_converter. Deal with the things that JSON can't encode.
 
     Args:
         o:

--- a/tests/Jenkinsfile
+++ b/tests/Jenkinsfile
@@ -35,7 +35,8 @@ pipeline {
                 }
                 dir('tests/unit/pipeline/filter') {
                     sh 'python3 -m coverage run -a --branch --data-file=../../.coverage --omit="*/tests/*,*/dist-packages/*" test_feature_groups.py'
-                    sh 'python3 -m coverage run -a --branch --data-file=../../.coverage --omit="*/tests/*,*/dist-packages/*" test_filter_core.py'
+                    sh 'python3 -m coverage run -a --branch --data-file=../../.coverage --omit="*/tests/*,*/dist-packages/*" test_filtercore.py'
+                    sh 'python3 -m coverage run -a --branch --data-file=../../.coverage --omit="*/tests/*,*/dist-packages/*" test_filters.py'
                     sh 'python3 -m coverage run -a --branch --data-file=../../.coverage --omit="*/tests/*,*/dist-packages/*" test_filter_runner.py'
                     sh 'python3 -m coverage run -a --branch --data-file=../../.coverage --omit="*/tests/*,*/dist-packages/*" test_watchlists.py'
                     sh 'python3 -m coverage run -a --branch --data-file=../../.coverage --omit="*/tests/*,*/dist-packages/*" test_watchmaps.py'

--- a/tests/unit/pipeline/filter/test_filter_core.py
+++ b/tests/unit/pipeline/filter/test_filter_core.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import psutil
 import context
 from filtercore import Filter
+from filters import dispose_kafka
 import re
 
 
@@ -205,22 +206,34 @@ class FilterTest(unittest.TestCase):
 
 
     @patch('filtercore.manage_status')
-    def test_dispose_kafka(self, mock_manage_status)
-
-
+    def test_dispose_kafka_produce(self, mock_manage_status):
+        """ Test that the right call is made to manage_status when disposing kafka under quota """
         mock_producer = unittest.mock.MagicMock()
-        query_results = [{'apple':1, 'pear':2}]
-        query = {'bytes_produced': 100, 'byte_quota':200, 'topic_name':'tpc'}
+        query_results = [{'apple':1, 'pear':2}]   # list of output results
+
+        query = {'bytes_produced': 100, 
+                 'byte_quota'    : 200,           # under quota
+                 'topic_name':'tpc'}
         nid = 0
         dispose_kafka(mock_producer, query_results, query, mock_manage_status, nid)
+        expect = {'tpc_bytes_produced': 23,       # expect production
+                  'tpc_alerts_produced':1}
+        mock_manage_status.add.assert_called_with(expect, 0)
 
+    @patch('filtercore.manage_status')
+    def test_dispose_kafka_reject(self, mock_manage_status):
+        """ Test that the right call is made to manage_status when disposing kafka over quota """
+        mock_producer = unittest.mock.MagicMock()
+        query_results = [{'apple':1, 'pear':2}]   # list of output results
 
-        expect_produce = ({'tpc_bytes_produced': 50, 'tpc_alerts_produced':1}, 0))
-        mock_manage_status.add.assert_called_with(expect_produce)
-
-
-
-
+        query = {'bytes_produced': 300, 
+                 'byte_quota'    : 200,           # over quota
+                 'topic_name':'tpc'}
+        nid = 0
+        dispose_kafka(mock_producer, query_results, query, mock_manage_status, nid)
+        expect = {'tpc_bytes_rejected': 23,       # expect rejection
+                  'tpc_alerts_rejected':1}
+        mock_manage_status.add.assert_called_with(expect, 0)
 
     @patch('filtercore.Filter.execute_query')
     def test_transfer_to_main_local_error(self, mock_execute_query):

--- a/tests/unit/pipeline/filter/test_filter_core.py
+++ b/tests/unit/pipeline/filter/test_filter_core.py
@@ -1,10 +1,13 @@
 import unittest, unittest.mock
 from unittest.mock import patch
 
+import datetime, json
+import numpy as np
 import psutil
 import context
 from filtercore import Filter
 from filters import dispose_kafka
+from filters import crap_converter
 import re
 
 
@@ -204,6 +207,19 @@ class FilterTest(unittest.TestCase):
         mock_manage_status.assert_called_once()
         mock_manage_status.return_value.add.assert_called_once()
 
+    def test_crap_converter(self):
+        """ Make sure that JSO can't reject the odd types it may get """
+        c = {
+            'date': datetime.datetime(2026, 2, 8, 9, 19, 19),
+            'np1': np.float32(1.5),
+            'np2': np.float64(1.5),
+            'np3': np.int32(10),
+            'np4': np.int64(10),
+            'none': None,
+        }
+        expect = '{"date": "2026-02-08 09:19:19", "np1": "1.5", "np2": 1.5, "np3": "10", "np4": "10", "none": null}'
+        out = json.dumps(c, default=crap_converter)
+        self.assertEqual(out, expect)
 
     @patch('filtercore.manage_status')
     def test_dispose_kafka_produce(self, mock_manage_status):

--- a/tests/unit/pipeline/filter/test_filter_core.py
+++ b/tests/unit/pipeline/filter/test_filter_core.py
@@ -203,6 +203,25 @@ class FilterTest(unittest.TestCase):
         mock_manage_status.assert_called_once()
         mock_manage_status.return_value.add.assert_called_once()
 
+
+    @patch('filtercore.manage_status')
+    def test_dispose_kafka(self, mock_manage_status)
+
+
+        mock_producer = unittest.mock.MagicMock()
+        query_results = [{'apple':1, 'pear':2}]
+        query = {'bytes_produced': 100, 'byte_quota':200, 'topic_name':'tpc'}
+        nid = 0
+        dispose_kafka(mock_producer, query_results, query, mock_manage_status, nid)
+
+
+        expect_produce = ({'tpc_bytes_produced': 50, 'tpc_alerts_produced':1}, 0))
+        mock_manage_status.add.assert_called_with(expect_produce)
+
+
+
+
+
     @patch('filtercore.Filter.execute_query')
     def test_transfer_to_main_local_error(self, mock_execute_query):
         """Test that an error when building the CSV causes transfer_to_main to return None"""

--- a/tests/unit/pipeline/filter/test_filtercore.py
+++ b/tests/unit/pipeline/filter/test_filtercore.py
@@ -1,13 +1,9 @@
 import unittest, unittest.mock
 from unittest.mock import patch
 
-import datetime, json
-import numpy as np
 import psutil
 import context
 from filtercore import Filter
-from filters import dispose_kafka
-from filters import crap_converter
 import re
 
 
@@ -206,50 +202,6 @@ class FilterTest(unittest.TestCase):
         mock_consumer.poll.assert_called_once()
         mock_manage_status.assert_called_once()
         mock_manage_status.return_value.add.assert_called_once()
-
-    def test_crap_converter(self):
-        """ Make sure that JSO can't reject the odd types it may get """
-        c = {
-            'date': datetime.datetime(2026, 2, 8, 9, 19, 19),
-            'np1': np.float32(1.5),
-            'np2': np.float64(1.5),
-            'np3': np.int32(10),
-            'np4': np.int64(10),
-            'none': None,
-        }
-        expect = '{"date": "2026-02-08 09:19:19", "np1": "1.5", "np2": 1.5, "np3": "10", "np4": "10", "none": null}'
-        out = json.dumps(c, default=crap_converter)
-        self.assertEqual(out, expect)
-
-    @patch('filtercore.manage_status')
-    def test_dispose_kafka_produce(self, mock_manage_status):
-        """ Test that the right call is made to manage_status when disposing kafka under quota """
-        mock_producer = unittest.mock.MagicMock()
-        query_results = [{'apple':1, 'pear':2}]   # list of output results
-
-        query = {'bytes_produced': 100, 
-                 'byte_quota'    : 200,           # under quota
-                 'topic_name':'tpc'}
-        nid = 0
-        dispose_kafka(mock_producer, query_results, query, mock_manage_status, nid)
-        expect = {'tpc_bytes_produced': 23,       # expect production
-                  'tpc_alerts_produced':1}
-        mock_manage_status.add.assert_called_with(expect, 0)
-
-    @patch('filtercore.manage_status')
-    def test_dispose_kafka_reject(self, mock_manage_status):
-        """ Test that the right call is made to manage_status when disposing kafka over quota """
-        mock_producer = unittest.mock.MagicMock()
-        query_results = [{'apple':1, 'pear':2}]   # list of output results
-
-        query = {'bytes_produced': 300, 
-                 'byte_quota'    : 200,           # over quota
-                 'topic_name':'tpc'}
-        nid = 0
-        dispose_kafka(mock_producer, query_results, query, mock_manage_status, nid)
-        expect = {'tpc_bytes_rejected': 23,       # expect rejection
-                  'tpc_alerts_rejected':1}
-        mock_manage_status.add.assert_called_with(expect, 0)
 
     @patch('filtercore.Filter.execute_query')
     def test_transfer_to_main_local_error(self, mock_execute_query):

--- a/tests/unit/pipeline/filter/test_filters.py
+++ b/tests/unit/pipeline/filter/test_filters.py
@@ -1,0 +1,61 @@
+import unittest, unittest.mock
+from unittest.mock import patch
+
+import context
+import datetime, json
+import numpy as np
+from filters import dispose_kafka
+from filters import crap_converter
+
+
+class FilterTest(unittest.TestCase):
+    def test_crap_converter(self):
+        """ Make sure that JSO can't reject the odd types it may get """
+        c = {
+            'date': datetime.datetime(2026, 2, 8, 9, 19, 19),
+            'np1': np.float32(1.5),
+            'np2': np.float64(1.5),
+            'np3': np.int32(10),
+            'np4': np.int64(10),
+            'none': None,
+            'cmpx': complex(2,3),
+        }
+        expect = """{"date": "2026-02-08 09:19:19", "np1": "1.5", "np2": 1.5, "np3": "10", "np4": "10", "none": null, "cmpx": "Unexpected type in json.dumps:<class 'complex'>"}"""
+        out = json.dumps(c, default=crap_converter)
+        self.assertEqual(out, expect)
+
+    def test_dispose_kafka_produce(self):
+        """ Test that the right call is made to manage_status when disposing kafka under quota """
+        mock_producer      = unittest.mock.MagicMock()
+        mock_manage_status = unittest.mock.MagicMock()
+        query_results = [{'apple':1, 'pear':2}]   # list of output results
+
+        query = {'bytes_produced': 100,
+                 'byte_quota'    : 200,           # under quota
+                 'topic_name':'tpc'}
+        nid = 0
+        dispose_kafka(mock_producer, query_results, query, mock_manage_status, nid)
+        expect = {'tpc_bytes_produced': 23,       # expect production
+                  'tpc_alerts_produced':1}
+        mock_manage_status.add.assert_called_with(expect, 0)
+
+    def test_dispose_kafka_reject(self):
+        """ Test that the right call is made to manage_status when disposing kafka over quota """
+        mock_producer      = unittest.mock.MagicMock()
+        mock_manage_status = unittest.mock.MagicMock()
+        query_results = [{'apple':1, 'pear':2}]   # list of output results
+
+        query = {'bytes_produced': 300,
+                 'byte_quota'    : 200,           # over quota
+                 'topic_name':'tpc'}
+        nid = 0
+        dispose_kafka(mock_producer, query_results, query, mock_manage_status, nid)
+        expect = {'tpc_bytes_rejected': 23,       # expect rejection
+                  'tpc_alerts_rejected':1}
+        mock_manage_status.add.assert_called_with(expect, 0)
+
+if __name__ == '__main__':
+    import xmlrunner 
+    runner = xmlrunner.XMLTestRunner(output='test-reports')
+    unittest.main(testRunner=runner)
+    unittest.main()

--- a/webserver/lasair/apps/filter_query/models.py
+++ b/webserver/lasair/apps/filter_query/models.py
@@ -15,6 +15,7 @@ class filter_query(models.Model):
     tables = models.CharField(max_length=4096, blank=True, null=True)
     public = models.BooleanField(blank=True, null=True)
     active = models.IntegerField(blank=True, null=True)
+    byte_quota = models.IntegerField(blank=True, null=True)
     topic_name = models.CharField(max_length=256, blank=True, null=True)
     real_sql = models.CharField(max_length=4096, blank=True, null=True)
     date_created = models.DateTimeField(auto_now_add=True, editable=False, blank=True, null=True)

--- a/webserver/lasair/apps/filter_query/urls.py
+++ b/webserver/lasair/apps/filter_query/urls.py
@@ -8,5 +8,4 @@ urlpatterns = [
     path('filters/<int:mq_id>/update/', views.filter_query_create, name='filter_query_update'),
     path('filters/<int:mq_id>/', views.filter_query_detail, name='filter_query_detail'),
     path('filters/<int:mq_id>/<slug:action>/', views.filter_query_detail, name='filter_query_detail_run'),
-    path('filters/log/(?P<topic>[-a-zA-Z0-9_.]+)/', views.filter_query_log, name='filter_query_log'),
 ]

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -151,7 +151,7 @@ def filter_query_detail(request, mq_id, action=False):
         newFil.name = request.POST.get('name')
         newFil.description = request.POST.get('description')
         newFil.active = request.POST.get('active')
-        newFil.topic_name = topic_name(newFil.name)
+        newFil.topic_name = topic_name(request.user.id, newFil.name)
 
         if request.POST.get('public'):
             newFil.public = True

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -151,6 +151,7 @@ def filter_query_detail(request, mq_id, action=False):
         newFil.name = request.POST.get('name')
         newFil.description = request.POST.get('description')
         newFil.active = request.POST.get('active')
+        newFil.topic_name = topic_name(newFil.name)
 
         if request.POST.get('public'):
             newFil.public = True

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -226,7 +226,7 @@ def filter_query_detail(request, mq_id, action=False):
         br = int(status.get(topic_name+'_bytes_rejected', 0))
         ap = int(status.get(topic_name+'_alerts_produced', 0))
         ar = int(status.get(topic_name+'_alerts_rejected', 0))
-        kafka_message = f'Your kafka stream has produced {ap:,} alerts today ({bp:,} bytes)'
+        kafka_message = f'Your kafka stream has produced {ap:,} alerts today ({bp:,} bytes of your quota of {filterQuery.byte_quota:,})'
         if ar > 0:
             kafka_message += f' and rejected {ar:,} alerts for being over quota'
     else:

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -1,4 +1,6 @@
-from src.topic_name import topic_name
+import sys
+sys.path.append('../common')
+from src.topic_name import topic_name as topicName
 from .utils import add_filter_query_metadata, run_filter, check_query_zero_limit, delete_stream_file, topic_refresh
 import random
 from src import date_nid, db_connect, manage_status
@@ -23,11 +25,9 @@ import time
 import datetime
 from django.contrib import messages
 import os
-import sys
 import sqlparse
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect
-sys.path.append('../common')
 
 
 @csrf_exempt
@@ -126,7 +126,7 @@ def filter_query_detail(request, mq_id, action=False):
                 datetime.datetime.now(tz=timezone.utc) + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
 
             # REFRESH STREAM
-            tn = topic_name(request.user.id, filterQuery.name)
+            tn = topicName(request.user.id, filterQuery.name)
             filterQuery.topic_name = tn
             delete_stream_file(request, filterQuery.name)
             message = ''
@@ -151,7 +151,7 @@ def filter_query_detail(request, mq_id, action=False):
         newFil.name = request.POST.get('name')
         newFil.description = request.POST.get('description')
         newFil.active = request.POST.get('active')
-        newFil.topic_name = topic_name(request.user.id, newFil.name)
+        newFil.topic_name = topicName(request.user.id, newFil.name)
 
         if request.POST.get('public'):
             newFil.public = True
@@ -386,14 +386,14 @@ def filter_query_create(request, mq_id=False):
                 filterQuery.conditions = conditions
                 filterQuery.real_sql = sqlquery_real
                 # REFRESH STREAM
-                tn = topic_name(request.user.id, filterQuery.name)
+                tn = topicName(request.user.id, filterQuery.name)
                 filterQuery.topic_name = tn
                 delete_stream_file(request, filterQuery.name)
                 verb = "updated"
 
             else:
                 sqlquery_real = sqlparse.format(build_query(selected, tables, conditions), reindent=True, keyword_case='upper', strip_comments=True)
-                tn = topic_name(request.user.id, name)
+                tn = topicName(request.user.id, name)
                 filterQuery = filter_query(user=request.user,
                                            name=name, description=description,
                                            public=public, active=active,

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -1,6 +1,5 @@
 import sys
 sys.path.append('../common')
-import settings as lasair_settings
 from src.topic_name import topic_name as topicName
 from .utils import add_filter_query_metadata, run_filter, check_query_zero_limit, delete_stream_file, topic_refresh
 import random
@@ -152,7 +151,7 @@ def filter_query_detail(request, mq_id, action=False):
         newFil.name = request.POST.get('name')
         newFil.description = request.POST.get('description')
         newFil.active = request.POST.get('active')
-        newFil.byte_query = lasair_settings.MAX_KAFKA_BYTES_PER_FILTER
+        newFil.byte_query = settings.KAFKA_BYTE_QUOTA
         newFil.topic_name = topicName(request.user.id, newFil.name)
 
         if request.POST.get('public'):
@@ -386,7 +385,7 @@ def filter_query_create(request, mq_id=False):
                 filterQuery.selected = selected
                 filterQuery.tables = tables
                 filterQuery.conditions = conditions
-                filterQuery.byte_quota = lasair_settings.MAX_KAFKA_BYTES_PER_FILTER
+                filterQuery.byte_quota = settings.KAFKA_BYTE_QUOTA
                 filterQuery.real_sql = sqlquery_real
                 # REFRESH STREAM
                 tn = topicName(request.user.id, filterQuery.name)
@@ -400,6 +399,7 @@ def filter_query_create(request, mq_id=False):
                 filterQuery = filter_query(user=request.user,
                                            name=name, description=description,
                                            public=public, active=active,
+                                           byte_quota = settings.KAFKA_BYTE_QUOTA,
                                            selected=selected, conditions=conditions, tables=tables,
                                            real_sql=sqlquery_real, topic_name=tn)
                 verb = "created"

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -1,5 +1,6 @@
 import sys
 sys.path.append('../common')
+import settings as lasair_settings
 from src.topic_name import topic_name as topicName
 from .utils import add_filter_query_metadata, run_filter, check_query_zero_limit, delete_stream_file, topic_refresh
 import random
@@ -151,6 +152,7 @@ def filter_query_detail(request, mq_id, action=False):
         newFil.name = request.POST.get('name')
         newFil.description = request.POST.get('description')
         newFil.active = request.POST.get('active')
+        newFil.byte_query = lasair_settings.MAX_KAFKA_BYTES_PER_FILTER
         newFil.topic_name = topicName(request.user.id, newFil.name)
 
         if request.POST.get('public'):
@@ -384,6 +386,7 @@ def filter_query_create(request, mq_id=False):
                 filterQuery.selected = selected
                 filterQuery.tables = tables
                 filterQuery.conditions = conditions
+                filterQuery.byte_quota = lasair_settings.MAX_KAFKA_BYTES_PER_FILTER
                 filterQuery.real_sql = sqlquery_real
                 # REFRESH STREAM
                 tn = topicName(request.user.id, filterQuery.name)

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -220,10 +220,10 @@ def filter_query_detail(request, mq_id, action=False):
         ms = manage_status.manage_status(msl)
         nid = date_nid.nid_now()
         status = ms.read(nid)
-        bp = status.get(topic_name+'_bytes_produced', 0)
-        br = status.get(topic_name+'_bytes_rejected', 0)
-        ap = status.get(topic_name+'_alerts_produced', 0)
-        ar = status.get(topic_name+'_alerts_rejected', 0)
+        bp = int(status.get(topic_name+'_bytes_produced', 0))
+        br = int(status.get(topic_name+'_bytes_rejected', 0))
+        ap = int(status.get(topic_name+'_alerts_produced', 0))
+        ar = int(status.get(topic_name+'_alerts_rejected', 0))
         kafka_message = f'Your kafka stream has produced {ap} alerts today ({bp} bytes)'
         if ar > 0:
             kafka_message += ' and rejected {ar} alerts for being over quota'

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -224,7 +224,9 @@ def filter_query_detail(request, mq_id, action=False):
         br = status.get(topic_name+'_bytes_rejected', 0)
         ap = status.get(topic_name+'_alerts_produced', 0)
         ar = status.get(topic_name+'_alerts_rejected', 0)
-        kafka_message = f'Your kafka stream has produced {ap} alerts today ({bp} bytes) and rejected {ar} alerts.'
+        kafka_message = f'Your kafka stream has produced {ap} alerts today ({bp} bytes)'
+        if ar > 0:
+            kafka_message += ' and rejected {ar} alerts for being over quota'
     else:
         kafka_message = ''
 

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -226,9 +226,9 @@ def filter_query_detail(request, mq_id, action=False):
         br = int(status.get(topic_name+'_bytes_rejected', 0))
         ap = int(status.get(topic_name+'_alerts_produced', 0))
         ar = int(status.get(topic_name+'_alerts_rejected', 0))
-        kafka_message = f'Your kafka stream has produced {ap} alerts today ({bp} bytes)'
+        kafka_message = f'Your kafka stream has produced {ap:,} alerts today ({bp:,} bytes)'
         if ar > 0:
-            kafka_message += ' and rejected {ar} alerts for being over quota'
+            kafka_message += f' and rejected {ar:,} alerts for being over quota'
     else:
         kafka_message = ''
 

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -1,7 +1,7 @@
 from src.topic_name import topic_name
 from .utils import add_filter_query_metadata, run_filter, check_query_zero_limit, delete_stream_file, topic_refresh
 import random
-from src import date_nid, db_connect
+from src import date_nid, db_connect, manage_status
 from django.shortcuts import render
 from django.shortcuts import render, get_object_or_404, redirect
 from django.db.models import Q
@@ -214,6 +214,20 @@ def filter_query_detail(request, mq_id, action=False):
     else:
         sortTable = True
 
+    # info about kafka records produced and rejected
+    if filterQuery.active >= 2:
+        topic_name = filterQuery.topic_name
+        ms = manage_status.manage_status(msl)
+        nid = date_nid.nid_now()
+        status = ms.read(nid)
+        bp = status.get(topic_name+'_bytes_produced', 0)
+        br = status.get(topic_name+'_bytes_rejected', 0)
+        ap = status.get(topic_name+'_alerts_produced', 0)
+        ar = status.get(topic_name+'_alerts_rejected', 0)
+        kafka_message = f'Your kafka stream has produced {ap} alerts today ({bp} bytes) and rejected {ar} alerts.'
+    else:
+        kafka_message = ''
+
     return render(request, 'filter_query/filter_query_detail.html', {
         'filterQ': filterQuery,
         'table': table,
@@ -222,9 +236,9 @@ def filter_query_detail(request, mq_id, action=False):
         "form": form,
         "duplicateForm": duplicateForm,
         'limit': str(limit),
-        'sortTable': sortTable
+        'sortTable': sortTable,
+        'kafka_message': kafka_message,
     })
-
 
 @login_required
 def filter_query_create(request, mq_id=False):

--- a/webserver/lasair/templates/includes/widgets/widget_filter_query_header.html
+++ b/webserver/lasair/templates/includes/widgets/widget_filter_query_header.html
@@ -105,10 +105,6 @@
 
 
                 {% if "filter/log/" not in request.path %}
-                    <a class="btn btn-sm btn-gray-600 border-white align-middle" href='{% url "filter_query_log" filterQ.topic_name %}' data-bs-toggle="tooltip" data-bs-placement="bottom" data-bs-title="listing all transients passing filter since its creation">
-
-                        {% include "includes/icons/icon_history.html" %}
-                        <span class="align-middle  d-none d-md-inline"  >History</span></a>
 
                     {% if user.is_authenticated and user.id == filterQ.user.id %}
 

--- a/webserver/lasair/templates/includes/widgets/widget_filter_query_header.html
+++ b/webserver/lasair/templates/includes/widgets/widget_filter_query_header.html
@@ -67,7 +67,10 @@
                 </small>
                 <small class="text-gray-500">
                     The filter is <b>{% if not filterQ.active %}not active{% elif filterQ.active == 1%} streamed via email {% elif filterQ.active == 2%} streamed via kafka</b> with the topic name <code>{{filterQ.topic_name}}</code><b> {% elif filterQ.active == 3%} streamed via kafka with lite lightcurve</b> with the topic name <code>{{filterQ.topic_name}}</code><b> {% elif filterQ.active == 4%} streamed via kafka with full alert</b> with the topic name <code>{{filterQ.topic_name}}</code><b> {% endif %}.</b> {% include "includes/info_tooltip.html" with info="when active, a filter will be dynamically matched against new transient alerts and the results streamed via email or kafka" position="auto" link=docroot|add:"/core_functions/alert-streams.html#kafka-streams" %}
-                </small>
+		</small><br/>
+		<small>
+		{{ kafka_message }}
+		</small>
             </div>
 
 

--- a/webserver/lasairapi/serializers.py
+++ b/webserver/lasairapi/serializers.py
@@ -402,22 +402,4 @@ class AnnotateSerializer(serializers.Serializer):
         except Exception as e:
             return {'error': "Query failed %d: %s\n" % (e.args[0], e.args[1])}
 
-        if active < 2:
-            return {'status': 'success', 'query': query}
-
-        # when active=2, we push a kafka message to make sure queries are run immediately
-        message = {'diaObjectId': diaObjectId, 'annotator': topic}
-        conf = {
-            'bootstrap.servers': lasair_settings.INTERNAL_KAFKA_PRODUCER,
-            'client.id': 'client-1',
-        }
-        producer = Producer(conf)
-        topicout = lasair_settings.ANNOTATION_TOPIC
-        try:
-            s = json.dumps(message)
-            producer.produce(topicout, s)
-        except Exception as e:
-            return {'error': "Kafka production failed: %s\n" % e}
-        producer.flush()
-
-        return {'status': 'success', 'query': query, 'annotation_topic': topicout, 'message': s}
+        return {'status': 'success', 'query': query}


### PR DESCRIPTION
(*) means already pushed in previous PR


- Public Kafka
  - Delivers choice of 3 kinds of Kafka output instead of 1 (*)
- Quota
  - Filter model includes `byte_quota` 
  - Stops any filter from emitting more than `byte_quota` per day
  - New and duplicated filters have byte_quota set to `settings.MAX_BYTE_QUOTA`
  - `byte_quota` can be changed in the admin page
- Lasair Statistics
  - Records with the lasair statistics system the number of bytes/alerts produced/rejected each day
  - Changes the `name` in `lasair_statistics` table to be 256 bytes
- Webserver
  - Fat kafka options: lightcurve-lite and full-alert when creating, modifying, or duplicating a filter (*)
  - Adds info to the filter detail page: "Your kafka stream has produced 345 alerts today (1,288,233 bytes of 1,000,000 quota) and rejected 30 alerts."
- Decluttering
  - Removes the fast annotation system that has never been used
  - Removes the "history" button on the filter page -- only used as a cache for email output from filter
- Recycling
  - Uses the same kafka producer instead of remaking it
  - Uses the same database session by passing `manage_status` instead of remaking it
- Resilience
  - Defensive encoding of JSON even with numpy primitives
- Tests
  - Making the lite lightcurve
  - Accept/reject in dispose_kafka
  - JSON handling of datetime and numpy
-----------
To implement this code:

In `webserver/lasair/settings.py` for webserver put
    `KAFKA_BYTE_QUOTA= 100000000`

For MySQL
- `ALTER TABLE lasair_statistics MODIFY COLUMN name varchar(256);`
- `ALTER TABLE myqueries ADD COLUMN byte_quota int ;`
- `UPDATE myqueries SET byte_quota=100000000;`
