### PR TITLE
Unlimited byte quota for fat kafka

### DIFF
--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -340,7 +340,7 @@ def dispose_kafka(producer, query_results, query, ms, nid):
     # First decide if this filter has already produced enough
     bp = query.get('bytes_produced', 0)
     bq = query['byte_quota']
-    will_produce = (bp < bq) or (bq == 0)
+    will_produce = (bp < bq) or (bq == -1)
 
     nbytes = 0
     nalert = 0

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -340,7 +340,7 @@ def dispose_kafka(producer, query_results, query, ms, nid):
     # First decide if this filter has already produced enough
     bp = query.get('bytes_produced', 0)
     bq = query['byte_quota']
-    will_produce = (bp < bq)
+    will_produce = (bp < bq) or (bq == 0)
 
     nbytes = 0
     nalert = 0


### PR DESCRIPTION
If the byte quota for a filter is zero, it means unlimited
