### PR TITLE
Feature/annotation statistics

### DIFF
--- a/utility/annotationStatistics.py
+++ b/utility/annotationStatistics.py
@@ -29,10 +29,14 @@ def fast_filters(cursor, ann_name):
     query += "WHERE tables LIKE '%%%s%%' and active > 0 ORDER BY last_name"
     query = query % ann_name
     cursor.execute(query)
-    print('\n** Fast annotation filters resulting from %s' % ann_name)
-    print('   Last name  active  Filter name')
+    s = ''
+    s += '\n** Fast annotation filters resulting from %s\n' % ann_name
+    s += '   Last name  active  Filter name\n'
+    n = 0
     for row in cursor:
-        print('%15s %d %s' % (row['last_name'], row['active'], row['name']))
+        n += 1
+        s += '%15s %d %s\n' % (row['last_name'], row['active'], row['name'])
+    return (n, s)
 
 def bytes_out(cursor, filter_name):
     # How many bytes output on public Kafka by this filter, for the last 7 days
@@ -68,8 +72,9 @@ if __name__ == "__main__":
     if active  == 1:
         print('\nNORMAL ANNOTATOR')
     else:
-        print('\nFAST ANNOTATOR')
-        fast_filters  (cursor, ann_name)
+        (n_filter, list_filter) = fast_filters  (cursor, ann_name)
+        print('\nFAST ANNOTATOR with %d filters:' % n_filter)
+        print(list_filter)
 
     if feeder_name:
         bytes_out     (cursor, feeder_name)

--- a/utility/annotationStatistics.py
+++ b/utility/annotationStatistics.py
@@ -30,13 +30,14 @@ def fast_filters(cursor, ann_name):
     query = query % ann_name
     cursor.execute(query)
     s = ''
-    s += '\n** Fast annotation filters resulting from %s\n' % ann_name
-    s += '   Last name  active  Filter name\n'
-    n = 0
+    n_filter = 0
     for row in cursor:
-        n += 1
+        n_filter += 1
         s += '%15s %d %s\n' % (row['last_name'], row['active'], row['name'])
-    return (n, s)
+
+    print('\n** %s is a FAST ANNOTATOR with %d filters:' % (ann_name, n_filter))
+    print('   Last name  active  Filter name')
+    print(s)
 
 def bytes_out(cursor, filter_name):
     # How many bytes output on public Kafka by this filter, for the last 7 days
@@ -70,11 +71,9 @@ if __name__ == "__main__":
 
     active = annotations_in(cursor, ann_name)
     if active  == 1:
-        print('\nNORMAL ANNOTATOR')
+        print('\n**%s is a NORMAL ANNOTATOR' % ann_name)
     else:
-        (n_filter, list_filter) = fast_filters  (cursor, ann_name)
-        print('\nFAST ANNOTATOR with %d filters:' % n_filter)
-        print(list_filter)
+        fast_filters  (cursor, ann_name)
 
     if feeder_name:
         bytes_out     (cursor, feeder_name)

--- a/utility/annotationStatistics.py
+++ b/utility/annotationStatistics.py
@@ -41,7 +41,7 @@ def bytes_out(cursor, filter_name):
     query = query % (nid-7, filter_name)
     cursor.execute(query)
     print('\n** Bytes out by Kafka to  %s' % filter_name)
-    print(' date    Mbytes')
+    print(' date    bytes')
     for row in cursor:
         date = date_nid.nid_to_date(row['nid'])
         bytes = f'{int(row["value"]):,}'

--- a/utility/annotationStatistics.py
+++ b/utility/annotationStatistics.py
@@ -1,5 +1,5 @@
 """ annotationStatistics
-    Print out the statistics for the lvra system
+    Print out the statistics for complex annotators
 """
 import sys
 sys.path.append('../common')
@@ -7,6 +7,7 @@ from src import date_nid
 import src.db_connect as db_connect
 
 def bytes_out(cursor, query_name):
+    # How many bytes output on public Kafka by this filter, for the last 7 days
     nid = date_nid.nid_now()
     query = 'SELECT name,value,nid FROM lasair_statistics WHERE nid>%d AND name LIKE "%%%s_bytes%%"'
     query = query % (nid-7, query_name)
@@ -17,6 +18,7 @@ def bytes_out(cursor, query_name):
         print('%s %10.0f' % (date_nid.nid_to_date(row['nid']), (row['value']/1000000)))
 
 def annotations_in(cursor, ann_name):
+    # How many annotations contributed by this annotator, for the last 7 days
     query = "SELECT count(*) AS nann, DATE(timestamp) as date FROM annotations "
     query += "WHERE topic='%s' AND timestamp > DATE(NOW() - INTERVAL 7 DAY) "
     query += "GROUP BY DAY(timestamp), MONTH(timestamp), YEAR(timestamp)"
@@ -28,6 +30,7 @@ def annotations_in(cursor, ann_name):
         print('%s %8d' % (row['date'], row['nann']))
 
 def fast_filters(cursor, ann_name):
+    # List of active filters that are immediately run as a result of the fast annotator
     query = " SELECT last_name, active, name FROM myqueries JOIN auth_user ON user=id "
     query += "WHERE tables LIKE '%%%s%%' and active > 0 ORDER BY last_name"
     query = query % ann_name

--- a/utility/annotationStatistics.py
+++ b/utility/annotationStatistics.py
@@ -6,17 +6,6 @@ sys.path.append('../common')
 from src import date_nid
 import src.db_connect as db_connect
 
-def bytes_out(cursor, query_name):
-    # How many bytes output on public Kafka by this filter, for the last 7 days
-    nid = date_nid.nid_now()
-    query = 'SELECT name,value,nid FROM lasair_statistics WHERE nid>%d AND name LIKE "%%%s_bytes%%"'
-    query = query % (nid-7, query_name)
-    cursor.execute(query)
-    print('** Megabytes in %s' % query_name)
-    print(' date    Mbytes')
-    for row in cursor:
-        print('%s %10.0f' % (date_nid.nid_to_date(row['nid']), (row['value']/1000000)))
-
 def annotations_in(cursor, ann_name):
     # How many annotations contributed by this annotator, for the last 7 days
     query = "SELECT count(*) AS nann, DATE(timestamp) as date FROM annotations "
@@ -24,10 +13,15 @@ def annotations_in(cursor, ann_name):
     query += "GROUP BY DAY(timestamp), MONTH(timestamp), YEAR(timestamp)"
     query = query % ann_name
     cursor.execute(query)
-    print('\n** Annotations in %s' % ann_name)
+    print('\n** Annotations ingested for %s' % ann_name)
     print(' date    number')
     for row in cursor:
         print('%s %8d' % (row['date'], row['nann']))
+
+    query = f'SELECT active FROM annotators WHERE topic="{ann_name}"'
+    cursor.execute(query)
+    for row in cursor:
+        return row['active']
 
 def fast_filters(cursor, ann_name):
     # List of active filters that are immediately run as a result of the fast annotator
@@ -35,15 +29,48 @@ def fast_filters(cursor, ann_name):
     query += "WHERE tables LIKE '%%%s%%' and active > 0 ORDER BY last_name"
     query = query % ann_name
     cursor.execute(query)
-    print('\n** Fast annotation filters from %s' % ann_name)
+    print('\n** Fast annotation filters resulting from %s' % ann_name)
     print('   Last name  active  Filter name')
     for row in cursor:
         print('%15s %d %s' % (row['last_name'], row['active'], row['name']))
 
+def bytes_out(cursor, filter_name):
+    # How many bytes output on public Kafka by this filter, for the last 7 days
+    nid = date_nid.nid_now()
+    query = 'SELECT name,value,nid FROM lasair_statistics WHERE nid>%d AND name LIKE "%%%s_bytes%%"'
+    query = query % (nid-7, filter_name)
+    cursor.execute(query)
+    print('\n** Bytes out by Kafka to  %s' % filter_name)
+    print(' date    Mbytes')
+    for row in cursor:
+        date = date_nid.nid_to_date(row['nid'])
+        bytes = f'{int(row["value"]):,}'
+        print('%s %20s' % (date, bytes))
+
 if __name__ == "__main__":
+    import os, sys
+    feeder_name = None
+    if len(sys.argv) > 1:
+        ann_name    = sys.argv[1]
+    if len(sys.argv) > 2:
+        feeder_name = sys.argv[2]
+    if len(sys.argv) == 1:
+        print('Usage: python3 annotationStatistics.py <annotation_name> <feeder_name>')
+        print('examples:')
+        print('  python3 annotationStatistics.py r0b_lvra lvra_fodder')
+        print('  python3 annotationStatistics.py NEEDLE_LSST needle_input_filter_test')
+        sys.exit()
+
     msl = db_connect.remote()
     cursor  = msl.cursor(buffered=True, dictionary=True)
-    bytes_out     (cursor, 'lvra-fodder')
-    annotations_in(cursor, 'r0b_lvra')
-    fast_filters  (cursor, 'r0b_lvra')
+
+    active = annotations_in(cursor, ann_name)
+    if active  == 1:
+        print('\nNORMAL ANNOTATOR')
+    else:
+        print('\nFAST ANNOTATOR')
+        fast_filters  (cursor, ann_name)
+
+    if feeder_name:
+        bytes_out     (cursor, feeder_name)
 

--- a/utility/annotationStatistics.py
+++ b/utility/annotationStatistics.py
@@ -1,0 +1,46 @@
+""" annotationStatistics
+    Print out the statistics for the lvra system
+"""
+import sys
+sys.path.append('../common')
+from src import date_nid
+import src.db_connect as db_connect
+
+def bytes_out(cursor, query_name):
+    nid = date_nid.nid_now()
+    query = 'SELECT name,value,nid FROM lasair_statistics WHERE nid>%d AND name LIKE "%%%s_bytes%%"'
+    query = query % (nid-7, query_name)
+    cursor.execute(query)
+    print('** Megabytes in %s' % query_name)
+    print(' date    Mbytes')
+    for row in cursor:
+        print('%s %10.0f' % (date_nid.nid_to_date(row['nid']), (row['value']/1000000)))
+
+def annotations_in(cursor, ann_name):
+    query = "SELECT count(*) AS nann, DATE(timestamp) as date FROM annotations "
+    query += "WHERE topic='%s' AND timestamp > DATE(NOW() - INTERVAL 7 DAY) "
+    query += "GROUP BY DAY(timestamp), MONTH(timestamp), YEAR(timestamp)"
+    query = query % ann_name
+    cursor.execute(query)
+    print('\n** Annotations in %s' % ann_name)
+    print(' date    number')
+    for row in cursor:
+        print('%s %8d' % (row['date'], row['nann']))
+
+def fast_filters(cursor, ann_name):
+    query = " SELECT last_name, active, name FROM myqueries JOIN auth_user ON user=id "
+    query += "WHERE tables LIKE '%%%s%%' and active > 0 ORDER BY last_name"
+    query = query % ann_name
+    cursor.execute(query)
+    print('\n** Fast annotation filters from %s' % ann_name)
+    print('   Last name  active  Filter name')
+    for row in cursor:
+        print('%15s %d %s' % (row['last_name'], row['active'], row['name']))
+
+if __name__ == "__main__":
+    msl = db_connect.remote()
+    cursor  = msl.cursor(buffered=True, dictionary=True)
+    bytes_out     (cursor, 'lvra-fodder')
+    annotations_in(cursor, 'r0b_lvra')
+    fast_filters  (cursor, 'r0b_lvra')
+


### PR DESCRIPTION
Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

This utility gathers statistics about 
- the numbers of annotations coming from selected annotators, especially the "fast" annotators; 
- the list of active filters that respond to fast annotators
- number of Galera queries is product of number of ann and number of FA filters
- Feeding filter: number of bytes is stress on public kafka

Example output
```
** Annotations ingested for r0b_lvra
 date    number
2026-03-02       99
2026-03-03       24
2026-03-04       16
2026-03-06       92
2026-03-07       72
2026-03-08      192
2026-03-09      303

** r0b_lvra is a FAST ANNOTATOR with 36 filters:
   Last name  active  Filter name
                1 SN-like candidates with z_spec > 0.1
         Dreams 1 Unexpected Burst of Light (original)
         Dreams 1 Unexpected Burst of Light (public)
         Dreams 1 LSST SN Ia 
     Killestein 1 GOTO x-matches
        Nicholl 2 Intrinsically luminous
     Pastorello 1 Gap Transient candidates
  Perez-Fournon 1 _Rubin_specz_or_photz_lt0.3
  Perez-Fournon 1 _Rubin_specz_gt_0.3

[snip]

** Bytes out by Kafka to  lvra_fodder
 date    bytes
20260303           73,429,900
20260304            3,092,760
20260306          657,366,000
20260307          491,621,000
20260308          425,573,000
20260309        2,078,750,000
