### PR TITLE
Email digest

### DIFF
--- a/deploy/common/settings.py.j2
+++ b/deploy/common/settings.py.j2
@@ -18,8 +18,10 @@ KAFKA_GROUPID          = '{{ lasair_name }}' + '01'
 # with its username and password
 {% if groups['kafka_pub'] is defined and groups['kafka_pub']|length > 0 %}
 PUBLIC_KAFKA_SERVER    = "{{ groups['kafka_pub'][0] }}:29092"
+PUBLIC_KAFKA_READONLY  = "{{ groups['kafka_pub'][0] }}:9092"
 {% else %}
 PUBLIC_KAFKA_SERVER    = None
+PUBLIC_KAFKA_READONLY  = None
 {% endif %}
 PUBLIC_KAFKA_USERNAME  = "{{ kafka_secret.admin_username }}"
 PUBLIC_KAFKA_PASSWORD  = "{{ kafka_secret.admin_password }}"

--- a/deploy/roles/lasair_service/tasks/cron.yml
+++ b/deploy/roles/lasair_service/tasks/cron.yml
@@ -96,3 +96,12 @@
     weekday: '0'
     job:    "(cd {{ ansible_env.HOME }}/{{ git_name }}/services; {{ venv_path }}/bin/python3 check_expire.py --action=warning    --days=28)"
  
+# Send daily email digests
+- name: "Crontab for email digest"
+  cron:
+    name:   "Email digest"
+    user:   "{{ ansible_env.USER }}"
+    hour: '18'
+    minute: '5'
+    job:    "(cd {{ ansible_env.HOME }}/{{ git_name }}/services; {{ venv_path }}/bin/python3 email_digest.py)"
+

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -196,21 +196,20 @@ def dispose_query_results(query, query_results, fltr, ms, nid):
         return 0
     active = query['active']
 
-    # if active == 1:
-    #     # send results by email if 24 hours has passed, returns time of last email send
-    #     digest, last_entry, last_email = fetch_digest(query['topic_name'])
-    #     allrecords = (query_results + digest)[:10000]
-    #     if fltr.send_email:
-    #         last_email = dispose_email(fltr, allrecords, last_email, query)
-    #     utcnow = datetime.datetime.now(datetime.UTC)
-    #     write_digest(allrecords, query['topic_name'], utcnow, last_email)
+    if active == 1:
+        # send results by email if 24 hours has passed, returns time of last email send
+        digest, last_entry, last_email = fetch_digest(query['topic_name'])
+        allrecords = (query_results + digest)[:10000]
+        if fltr.send_email:
+            last_email = dispose_email(fltr, allrecords, last_email, query)
+        utcnow = datetime.datetime.now(datetime.UTC)
+        write_digest(allrecords, query['topic_name'], utcnow, last_email)
 
     # send results by kafka on given topic
     BASIC_KAFKA     = 2
     LIGHTCURVE_LITE = 3
     LIGHTCURVE_FULL = 4
-    # note that email digest also requires Kafka output
-    if not fltr.send_kafka or active < 1:
+    if not fltr.send_kafka or active < BASIC_KAFKA:
         return len(query_results)
 
     # try to append the lightcurve info

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -209,7 +209,8 @@ def dispose_query_results(query, query_results, fltr, ms, nid):
     BASIC_KAFKA     = 2
     LIGHTCURVE_LITE = 3
     LIGHTCURVE_FULL = 4
-    if not fltr.send_kafka or active < BASIC_KAFKA:
+    # note that email digest also requires Kafka output
+    if not fltr.send_kafka or active < 1:
         return len(query_results)
 
     # try to append the lightcurve info

--- a/pipeline/filter/filters.py
+++ b/pipeline/filter/filters.py
@@ -196,14 +196,14 @@ def dispose_query_results(query, query_results, fltr, ms, nid):
         return 0
     active = query['active']
 
-    if active == 1:
-        # send results by email if 24 hours has passed, returns time of last email send
-        digest, last_entry, last_email = fetch_digest(query['topic_name'])
-        allrecords = (query_results + digest)[:10000]
-        if fltr.send_email:
-            last_email = dispose_email(fltr, allrecords, last_email, query)
-        utcnow = datetime.datetime.now(datetime.UTC)
-        write_digest(allrecords, query['topic_name'], utcnow, last_email)
+    # if active == 1:
+    #     # send results by email if 24 hours has passed, returns time of last email send
+    #     digest, last_entry, last_email = fetch_digest(query['topic_name'])
+    #     allrecords = (query_results + digest)[:10000]
+    #     if fltr.send_email:
+    #         last_email = dispose_email(fltr, allrecords, last_email, query)
+    #     utcnow = datetime.datetime.now(datetime.UTC)
+    #     write_digest(allrecords, query['topic_name'], utcnow, last_email)
 
     # send results by kafka on given topic
     BASIC_KAFKA     = 2

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -14,22 +14,45 @@ from docopt import docopt
 from src import db_connect
 from confluent_kafka import Consumer
 import settings
+from time import sleep
 
 
 args = docopt(__doc__)
 
 consumer_conf = {
-    'bootstrap.servers': '',
+    'bootstrap.servers': settings.PUBLIC_KAFKA_READONLY,
     'default.topic.config': {'auto.offset.reset': 'earliest'},
-    'client.id': 'client-1',
-    'group.id': '',
-    'enable.auto.commit': False,
+    'client.id': 'email_digest',
+    'group.id': 'email_digest',
+    'enable.auto.commit': True,
 }
 
+# Get a list of filters
 msl = db_connect.remote()
 cursor = msl.cursor(buffered=True, dictionary=True)
-query = f"SELECT topic_name, first_name, last_name, email FROM myqueries, auth_user WHERE auth_user.id=user AND active=1"
+query = "SELECT name, topic_name, first_name, last_name, email FROM myqueries, auth_user WHERE auth_user.id=user AND active=1"
 cursor.execute(query)
-for row in cursor:
-    print(row)
+filters = cursor.items()
 
+for f in filters:
+    # Get any new alerts
+    consumer = Consumer(consumer_conf)
+    consumer.subscribe([f['topic_name']])
+    alerts = []
+    for i in range(10):
+        msg = consumer.poll(timeout=1)
+        if msg is None:
+            # no messages available
+            sleep(1)
+            continue
+        if msg.error():
+            print('ERROR polling for alerts: ' + str(msg.error()))
+            break
+        alerts.append(msg.value())
+    consumer.close()
+
+    # Create digest email
+    if len(alerts) > 0:
+        digest = f"Lasair alert digest for filter {f['name']}\n\n"
+        for alert in alerts:
+            digest += alert + '\n'

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -79,13 +79,17 @@ def main(to_addr, groupid, fname):
     # Get a list of filters
     msl = db_connect.remote()
     cursor = msl.cursor(buffered=True, dictionary=True)
-    query = ("SELECT name, topic_name, first_name, last_name, email"
-             "FROM myqueries, auth_user"
-             "WHERE auth_user.id=user AND active=1")
+    query = ("SELECT name, topic_name, first_name, last_name, email "
+             "FROM myqueries, auth_user "
+             "WHERE auth_user.id=user ")
     if fname:
-        query += f" AND myqueries.name={fname}"
+        # get a specific query (for testing)
+        query += f"AND myqueries.name='{fname}'"
+    else:
+        # get all active=1 queries
+        query += "AND active=1"
     cursor.execute(query)
-    filters = cursor.items()
+    filters = cursor.fetchall()
 
     for f in filters:
         # Get any new alerts

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -25,10 +25,10 @@ import smtplib
 import json
 
 
-def send_email(to_addr: str, subject: str, message: str, message_html: str = None, message_json: str = None):
+def send_email(to_addr: str, fname: str, message: str, message_html: str = None, message_json: str = None):
     msg = MIMEMultipart('alternative')
 
-    msg['Subject'] = subject
+    msg['Subject'] = f"Lasair query {fname}"
     msg['From'] = settings.LASAIR_EMAIL
     msg['To'] = to_addr
 
@@ -36,7 +36,9 @@ def send_email(to_addr: str, subject: str, message: str, message_html: str = Non
     if message_html:
         msg.attach(MIMEText(message_html, 'html'))
     if message_json:
-        msg.attach(MIMEApplication(message_json, 'json'))
+        attachment = MIMEApplication(message_json, 'json', Name=f"{fname}.json")
+        attachment.add_header('Content-Disposition', 'attachment', filename=f"{fname}.json")
+        msg.attach(attachment)
     s = smtplib.SMTP('localhost')
     s.sendmail('lasair@lsst.ac.uk', to_addr, msg.as_string())
 
@@ -45,10 +47,10 @@ def format_line(alert):
     text = ' '.join(str(value) for key, value in alert.items()) + "\n"
     html = "<tr>"
     for key, value in alert.items():
-        if key == 'objectId':
+        if key == 'diaObjectId':
             html += f"<td><a href=\"https://{settings.LASAIR_URL}/objects/{str(value)}\">{str(value)}</a></td>"
         else:
-            html += str(value)
+            html += f"<td>{key} {str(value)}</td>"
     html += "</tr>\n"
     return text, html
 
@@ -56,6 +58,12 @@ def format_line(alert):
 def format_message(fname, alerts):
     text = f"Lasair alert digest for filter {fname}\n\n"
     html = f"<html><head><title>Lasair alert digest for filter {fname}</title></head><body><table>\n"
+    if len(alerts) > 0:
+        text += ' | '.join(alerts[0].keys()) + "\n"
+        html += "<tr>"
+        for key in alerts[0]:
+            html += f"<th>{key}</th>"
+        html += "</tr>\n"
     for alert in alerts:
         line_text, line_html = format_line(alert)
         text += line_text
@@ -96,10 +104,12 @@ def main(to_addr, groupid, fname):
         consumer = Consumer(consumer_conf)
         consumer.subscribe([f['topic_name']])
         alerts = []
-        for i in range(10):
+        i = 0
+        while i < 10:
             msg = consumer.poll(timeout=1)
             if msg is None:
                 # no messages available
+                i += 1
                 sleep(1)
                 continue
             if msg.error():
@@ -114,7 +124,7 @@ def main(to_addr, groupid, fname):
                 to_addr = f['email']
             text, html = format_message(f['name'], alerts)
             json_str = json.dumps(alerts, indent=2)
-            send_email(to_addr, f"Lasair query {f['name']}", text, html, json_str)
+            send_email(to_addr, f['name'], text, html, json_str)
 
 
 if __name__ == "__main__":

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -15,9 +15,10 @@ from src import db_connect
 from confluent_kafka import Consumer
 import settings
 from time import sleep
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+import smtplib
 
-
-args = docopt(__doc__)
 
 consumer_conf = {
     'bootstrap.servers': settings.PUBLIC_KAFKA_READONLY,
@@ -27,32 +28,59 @@ consumer_conf = {
     'enable.auto.commit': True,
 }
 
-# Get a list of filters
-msl = db_connect.remote()
-cursor = msl.cursor(buffered=True, dictionary=True)
-query = "SELECT name, topic_name, first_name, last_name, email FROM myqueries, auth_user WHERE auth_user.id=user AND active=1"
-cursor.execute(query)
-filters = cursor.items()
 
-for f in filters:
-    # Get any new alerts
-    consumer = Consumer(consumer_conf)
-    consumer.subscribe([f['topic_name']])
-    alerts = []
-    for i in range(10):
-        msg = consumer.poll(timeout=1)
-        if msg is None:
-            # no messages available
-            sleep(1)
-            continue
-        if msg.error():
-            print('ERROR polling for alerts: ' + str(msg.error()))
-            break
-        alerts.append(msg.value())
-    consumer.close()
+def send_email(to_addr: str, subject: str, message: str, message_html: str = None):
+    msg = MIMEMultipart('alternative')
 
-    # Create digest email
-    if len(alerts) > 0:
-        digest = f"Lasair alert digest for filter {f['name']}\n\n"
-        for alert in alerts:
-            digest += alert + '\n'
+    msg['Subject'] = subject
+    msg['From'] = settings.LASAIR_EMAIL
+    msg['To'] = to_addr
+
+    msg.attach(MIMEText(message, 'plain'))
+    if message_html:
+        msg.attach(MIMEText(message_html, 'html'))
+    s = smtplib.SMTP('localhost')
+    s.sendmail('lasair@lsst.ac.uk', to_addr, msg.as_string())
+
+
+def main():
+    # Get a list of filters
+    msl = db_connect.remote()
+    cursor = msl.cursor(buffered=True, dictionary=True)
+    query = ("SELECT name, topic_name, first_name, last_name, email"
+             "FROM myqueries, auth_user"
+             "WHERE auth_user.id=user AND active=1")
+    cursor.execute(query)
+    filters = cursor.items()
+
+    for f in filters:
+        # Get any new alerts
+        consumer = Consumer(consumer_conf)
+        consumer.subscribe([f['topic_name']])
+        alerts = []
+        for i in range(10):
+            msg = consumer.poll(timeout=1)
+            if msg is None:
+                # no messages available
+                sleep(1)
+                continue
+            if msg.error():
+                print('ERROR polling for alerts: ' + str(msg.error()))
+                break
+            alerts.append(msg.value())
+        consumer.close()
+
+        # Create and send digest email
+        if len(alerts) > 0:
+            digest = f"Lasair alert digest for filter {f['name']}\n\n"
+            for alert in alerts:
+                digest += alert + '\n'
+            send_email(f['email'], f"Lasair query {f['name']}", digest)
+
+
+if __name__ == "__main__":
+    args = docopt(__doc__)
+
+
+
+

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -2,10 +2,13 @@
 For each filter with email output, checks the associated Kafka topic for new alerts,
 builds a digest email and sends it. Intended to be run as a daily cronjob.
 Usage:
-    email_digest.py
+    email_digest.py [--email=<address> --group=<id>] [--filter=<name>]
 
 Options:
-    --help     Show usage information
+    --help             Show usage information
+    --email=<address>  Send all alerts here instead of to users (for testing)
+    --group=<id>       Group ID (for testing)
+    --filter=<name>    Limit to a single filter (for testing)
 """
 
 import sys
@@ -20,15 +23,6 @@ from email.mime.text import MIMEText
 from email.mime.application import MIMEApplication
 import smtplib
 import json
-
-
-consumer_conf = {
-    'bootstrap.servers': settings.PUBLIC_KAFKA_READONLY,
-    'default.topic.config': {'auto.offset.reset': 'earliest'},
-    'client.id': 'email_digest',
-    'group.id': 'email_digest',
-    'enable.auto.commit': True,
-}
 
 
 def send_email(to_addr: str, subject: str, message: str, message_html: str = None, message_json: str = None):
@@ -71,13 +65,25 @@ def format_message(fname, alerts):
     return text, html
 
 
-def main():
+def main(to_addr, groupid, fname):
+    if not groupid:
+        groupid = 'email_digest'
+    consumer_conf = {
+        'bootstrap.servers': settings.PUBLIC_KAFKA_READONLY,
+        'default.topic.config': {'auto.offset.reset': 'earliest'},
+        'client.id': 'email_digest',
+        'group.id': groupid,
+        'enable.auto.commit': True,
+    }
+
     # Get a list of filters
     msl = db_connect.remote()
     cursor = msl.cursor(buffered=True, dictionary=True)
     query = ("SELECT name, topic_name, first_name, last_name, email"
              "FROM myqueries, auth_user"
              "WHERE auth_user.id=user AND active=1")
+    if fname:
+        query += f" AND myqueries.name={fname}"
     cursor.execute(query)
     filters = cursor.items()
 
@@ -100,14 +106,22 @@ def main():
 
         # Create and send digest email
         if len(alerts) > 0:
+            if not to_addr:
+                to_addr = f['email']
             text, html = format_message(f['name'], alerts)
             json_str = json.dumps(alerts, indent=2)
-            send_email(f['email'], f"Lasair query {f['name']}", text, html, json_str)
+            send_email(to_addr, f"Lasair query {f['name']}", text, html, json_str)
 
 
 if __name__ == "__main__":
     args = docopt(__doc__)
-    main()
+    email = args.get('--email')
+    group = args.get('--group')
+    filter_name = args.get('--filter')
+    if email and not group or group and not email:
+        print('Either both email and group options must be set, or neither.')
+        sys.exit(1)
+    main(email, group, filter_name)
 
 
 

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -80,6 +80,7 @@ def main():
 
 if __name__ == "__main__":
     args = docopt(__doc__)
+    main()
 
 
 

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -17,7 +17,9 @@ import settings
 from time import sleep
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.mime.application import MIMEApplication
 import smtplib
+import json
 
 
 consumer_conf = {
@@ -29,7 +31,7 @@ consumer_conf = {
 }
 
 
-def send_email(to_addr: str, subject: str, message: str, message_html: str = None):
+def send_email(to_addr: str, subject: str, message: str, message_html: str = None, message_json: str = None):
     msg = MIMEMultipart('alternative')
 
     msg['Subject'] = subject
@@ -39,8 +41,34 @@ def send_email(to_addr: str, subject: str, message: str, message_html: str = Non
     msg.attach(MIMEText(message, 'plain'))
     if message_html:
         msg.attach(MIMEText(message_html, 'html'))
+    if message_json:
+        msg.attach(MIMEApplication(message_json, 'json'))
     s = smtplib.SMTP('localhost')
     s.sendmail('lasair@lsst.ac.uk', to_addr, msg.as_string())
+
+
+def format_line(alert):
+    text = ' '.join(str(value) for key, value in alert.items()) + "\n"
+    html = "<tr>"
+    for key, value in alert.items():
+        if key == 'objectId':
+            html += f"<td><a href=\"https://{settings.LASAIR_URL}/objects/{str(value)}\">{str(value)}</a></td>"
+        else:
+            html += str(value)
+    html += "</tr>\n"
+    return text, html
+
+
+def format_message(fname, alerts):
+    text = f"Lasair alert digest for filter {fname}\n\n"
+    html = f"<html><head><title>Lasair alert digest for filter {fname}</title></head><body><table>\n"
+    for alert in alerts:
+        line_text, line_html = format_line(alert)
+        text += line_text
+        html += line_html
+    text += "\n"
+    html += "</table></body></html>"
+    return text, html
 
 
 def main():
@@ -67,15 +95,14 @@ def main():
             if msg.error():
                 print('ERROR polling for alerts: ' + str(msg.error()))
                 break
-            alerts.append(msg.value())
+            alerts.append(json.loads(msg.value()))
         consumer.close()
 
         # Create and send digest email
         if len(alerts) > 0:
-            digest = f"Lasair alert digest for filter {f['name']}\n\n"
-            for alert in alerts:
-                digest += alert + '\n'
-            send_email(f['email'], f"Lasair query {f['name']}", digest)
+            text, html = format_message(f['name'], alerts)
+            json_str = json.dumps(alerts, indent=2)
+            send_email(f['email'], f"Lasair query {f['name']}", text, html, json_str)
 
 
 if __name__ == "__main__":

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -26,15 +26,17 @@ import json
 
 
 def send_email(to_addr: str, fname: str, message: str, message_html: str = None, message_json: str = None):
-    msg = MIMEMultipart('alternative')
+    msg = MIMEMultipart('mixed')
+    body = MIMEMultipart('alternative')
 
     msg['Subject'] = f"Lasair query {fname}"
     msg['From'] = settings.LASAIR_EMAIL
     msg['To'] = to_addr
 
-    msg.attach(MIMEText(message, 'plain'))
+    body.attach(MIMEText(message, 'plain'))
     if message_html:
-        msg.attach(MIMEText(message_html, 'html'))
+        body.attach(MIMEText(message_html, 'html'))
+    msg.attach(body)
     if message_json:
         attachment = MIMEApplication(message_json, 'json', Name=f"{fname}.json")
         attachment.add_header('Content-Disposition', 'attachment', filename=f"{fname}.json")
@@ -50,7 +52,7 @@ def format_line(alert):
         if key == 'diaObjectId':
             html += f"<td><a href=\"https://{settings.LASAIR_URL}/objects/{str(value)}\">{str(value)}</a></td>"
         else:
-            html += f"<td>{key} {str(value)}</td>"
+            html += f"<td>{str(value)}</td>"
     html += "</tr>\n"
     return text, html
 

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -1,0 +1,26 @@
+"""
+For each filter with email output, checks the associated Kafka topic for new alerts,
+builds a digest email and sends it. Intended to be run as a daily cronjob.
+Usage:
+    email_digest.py
+
+Options:
+    --help     Show usage information
+"""
+
+from docopt import docopt
+from src import db_connect
+
+
+def main():
+    msl = db_connect.remote()
+    cursor = msl.cursor(buffered=True, dictionary=True)
+    query = f"SELECT * FROM myqueries WHERE active>0"
+    cursor.execute(query)
+    for row in cursor:
+        print(row)
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__)
+    main()

--- a/services/email_digest.py
+++ b/services/email_digest.py
@@ -8,19 +8,28 @@ Options:
     --help     Show usage information
 """
 
+import sys
+sys.path.append('../common')
 from docopt import docopt
 from src import db_connect
+from confluent_kafka import Consumer
+import settings
 
 
-def main():
-    msl = db_connect.remote()
-    cursor = msl.cursor(buffered=True, dictionary=True)
-    query = f"SELECT * FROM myqueries WHERE active>0"
-    cursor.execute(query)
-    for row in cursor:
-        print(row)
+args = docopt(__doc__)
 
+consumer_conf = {
+    'bootstrap.servers': '',
+    'default.topic.config': {'auto.offset.reset': 'earliest'},
+    'client.id': 'client-1',
+    'group.id': '',
+    'enable.auto.commit': False,
+}
 
-if __name__ == '__main__':
-    args = docopt(__doc__)
-    main()
+msl = db_connect.remote()
+cursor = msl.cursor(buffered=True, dictionary=True)
+query = f"SELECT topic_name, first_name, last_name, email FROM myqueries, auth_user WHERE auth_user.id=user AND active=1"
+cursor.execute(query)
+for row in cursor:
+    print(row)
+


### PR DESCRIPTION
Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/2612264961/How+to+do+Pull+Request#STEP-3%3A-Issue-a-Pull-Request-on-Github

# CHECKLIST

- Have any tests been written to test the new code in this pull request?
  - [x] Yes. I have added the command to run the test below.
  - [ ] No. I have added the reason for the lack of testing below. 
- Have you added any new documentation for the changes in this pull-request?
  - [x] Yes. I state below where the documentation lives.
  - [ ] No. No new documentation was needed.

# NOTES

- Can be run from the command line with email/group/filter parameters in order to generate test emails
- POO updated (service node)
- Implements #513

# CHANGES

- Remove email processing from the filter stage - active=1 filters now treated the same as active=2
- Add email_digest.py service to get messages from kafka and send them as email digests
- Add a cron job in deploy to run the above daily
- Add extra lines to settings so that above can find the public kafka server
- Improved text and html formatting in email output
- Adds json output as an email attachment
