### PR TITLE
API and private watchlists/watchmaps

### DIFF
--- a/webserver/lasair/query_builder.py
+++ b/webserver/lasair/query_builder.py
@@ -115,7 +115,7 @@ def check_where_forbidden(where_condition):
     return None
 
 
-def check_query(select_expression, from_expression, where_condition):
+def check_query(select_expression, from_expression, where_condition, user=None):
     """ Check the query arguments with the functions above
     """
     # check if the select expression is OK
@@ -127,6 +127,51 @@ def check_query(select_expression, from_expression, where_condition):
     s = check_where_forbidden(where_condition)
     if s:
         return s
+
+    if not user:
+        return None
+    watchlist_id = None
+    area_ids     = []
+    msl          = None
+    # now check permissions for watchlists and watchmaps
+    tables = from_expression.split(',')
+    for _table in tables:
+        table = _table.strip().lower()
+
+        if table.startswith('watchlist:'):
+            w = table.split(':')
+            try:
+                watchlist_id = int(w[1])
+            except:
+                raise QueryBuilderError('Error in FROM list, %s not of the form watchlist:nnn' % table)
+
+        if table.startswith('area:') or table.startswith('watchmap:'):
+            w = table.split(':')
+            try:
+                area_ids = w[1].split('&')
+            except:
+                raise QueryBuilderError('Error in FROM list, %s not of the form area:nnn or watchmap:nnn' % table)
+
+    if watchlist_id:
+        if not msl: 
+            msl = db_connect.remote()
+            cursor = msl.cursor(buffered=True, dictionary=True)
+        query = f'SELECT public,user from watchlists where wl_id={watchlist_id}'
+        cursor.execute(query)
+        for row in cursor:
+            if row['public'] == 0 and row['user'] != user:
+                raise QueryBuilderError(f'Error: you do not have permission to access watchlist {watchlist_id}')
+
+    if len(area_ids) > 0:
+        if not msl: 
+            msl = db_connect.remote()
+            cursor = msl.cursor(buffered=True, dictionary=True)
+        for area_id in area_ids:
+            query = f'SELECT public,user from areas where ar_id={area_id}'
+            cursor.execute(query)
+            for row in cursor:
+                if row['public'] == 0 and row['user'] != user:
+                    raise QueryBuilderError(f'Error: you do not have permission to access watchmap {area_id}')
 
     return None
 

--- a/webserver/lasairapi/serializers.py
+++ b/webserver/lasairapi/serializers.py
@@ -314,7 +314,7 @@ class QuerySerializer(serializers.Serializer):
         else:
             offset = int(offset)
 
-        error = check_query(selected, tables, conditions)
+        error = check_query(selected, tables, conditions, user=userId)
         if error:
             return {"error": error}
 

--- a/webserver/lasairapi/serializers.py
+++ b/webserver/lasairapi/serializers.py
@@ -314,7 +314,11 @@ class QuerySerializer(serializers.Serializer):
         else:
             offset = int(offset)
 
-        error = check_query(selected, tables, conditions, user=userId)
+        try:
+            error = check_query(selected, tables, conditions, user=userId)
+        except Exception as e:
+            error = str(e)
+
         if error:
             return {"error": error}
 


### PR DESCRIPTION
Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/2612264961/How+to+do+Pull+Request#STEP-3%3A-Issue-a-Pull-Request-on-Github

# CHECKLIST

- Have any tests been written to test the new code in this pull request?
  - [ ] Yes. I have added the command to run the test below.
  - [x] No. I have added the reason for the lack of testing below. 
- Have you added any new documentation for the changes in this pull-request?
  - [ ] Yes. I state below where the documentation lives.
  - [x] No. No new documentation was needed.

# NOTES
When executing the "query" method of the API, there was a security hole which is now plugged. Given the wl_id of a private watchlist or watchmap, anyone could run queries against it. There is now a test to stop this. In the example below, the private watchlist is 9 and the API_TOKEN is not that of the owner.
```
L = lasair(API_TOKEN, endpoint=endpoint)
selected = 'objects.diaObjectId'
tables = 'objects,watchlist:9'
conditions = ''
results = L.query(selected, tables, conditions, limit=limit)
```

The result is:
`lasair.lasair.LasairError: Bad Request:{"error":"Error: you do not have permission to access watchlist 9"}`