### PR TITLE
10 messages for updated filter

### DIFF
--- a/tests/unit/pipeline/filter/settings.py
+++ b/tests/unit/pipeline/filter/settings.py
@@ -17,4 +17,4 @@ SCHEMA_VERSION = '10_0_A'
 PUBLIC_KAFKA_SERVER="lasair-lsst-dev-kafka_pub:29092"
 PUBLIC_KAFKA_USERNAME='blabla'
 PUBLIC_KAFKA_PASSWORD='junk'
-
+ANNOTATION_TOPIC='fast_annotations'

--- a/webserver/lasair/apps/filter_query/utils.py
+++ b/webserver/lasair/apps/filter_query/utils.py
@@ -189,8 +189,7 @@ def topic_refresh(real_sql, topic, limit=10):
         time.sleep(1)
         message += 'Topic %s deleted<br/>' % topic
     except Exception as e:
-        message += 'Topic is ' + topic + '<br/>'
-        message += str(e) + '<br/>'
+        pass
 
     timeout = 30
 

--- a/webserver/lasair/apps/filter_query/utils.py
+++ b/webserver/lasair/apps/filter_query/utils.py
@@ -206,7 +206,7 @@ def topic_refresh(real_sql, topic, active, limit=10):
     if active >= 3:
         lightcurve = lightcurve_fetcher(\
             cassandra_hosts=settings.CASSANDRA_HEAD,
-            reliabilityThreshold=0.5)
+            reliabilityThreshold=0.0)
 
     msl = db_connect.readonly()
     cursor = msl.cursor(buffered=True, dictionary=True)

--- a/webserver/lasair/apps/filter_query/utils.py
+++ b/webserver/lasair/apps/filter_query/utils.py
@@ -216,19 +216,22 @@ def topic_refresh(real_sql, topic, active, limit=10):
         for record in cursor:
             recorddict = dict(record)
 
-            # fetch lightcurve from cassandra
-            if 'diaObjectId' in recorddict and active >= 3:
-                diaObjectId = recorddict['diaObjectId']
-                (diaObject, diaSourcesList, diaForcedSourcesList) = \
-                    lightcurve.fetch(diaObjectId, lite=False)
-                alert = {
-                    'diaObjectId':diaObjectId,
-                    'diaObject':diaObject,
-                    'diaSourcesList':diaSourcesList,
-                    'diaForcedSourcesList':diaForcedSourcesList}
-                if active == 3:
-                    alert = lightcurve_lite(alert)
-                recorddict['alert'] = alert
+            if active >= 3:
+                # fetch lightcurve from cassandra
+                if 'diaObjectId' in recorddict and active >= 3:
+                    diaObjectId = recorddict['diaObjectId']
+                    (diaObject, diaSourcesList, diaForcedSourcesList) = \
+                        lightcurve.fetch(diaObjectId, lite=False)
+                    alert = {
+                        'diaObjectId':diaObjectId,
+                        'diaObject':diaObject,
+                        'diaSourcesList':diaSourcesList,
+                        'diaForcedSourcesList':diaForcedSourcesList}
+
+                    # convert to lite version if active == 3
+                    if active == 3: alert = lightcurve_lite(alert)
+
+                    recorddict['alert'] = alert
 
             query_results.append(recorddict)
     except Exception as e:

--- a/webserver/lasair/apps/filter_query/utils.py
+++ b/webserver/lasair/apps/filter_query/utils.py
@@ -4,12 +4,18 @@ from src.topic_name import topic_name
 from lasair.apps.db_schema.utils import get_schema, get_schema_dict, get_schema_for_query_selected
 from lasair.utils import datetime_converter
 import settings
-import os
+import os, sys
 import json
 import time
 from datetime import datetime
 from confluent_kafka import admin, Producer
 
+sys.path.append('lasair')
+from lightcurves import lightcurve_fetcher
+
+sys.path.append('../pipeline/filter')
+sys.path.append('../common/src')
+from util import lightcurve_lite
 
 def add_filter_query_metadata(
         filter_queries,
@@ -154,7 +160,7 @@ def check_query_zero_limit(real_sql):
         return message
 
 
-def topic_refresh(real_sql, topic, limit=10):
+def topic_refresh(real_sql, topic, active, limit=10):
     """*refresh a kafka topic on creation or update of a filter*
 
     **Key Arguments:**
@@ -196,6 +202,12 @@ def topic_refresh(real_sql, topic, limit=10):
     query = ('SET STATEMENT max_statement_time=%d FOR %s LIMIT %s'
              % (timeout, real_sql, limit))
 
+    # connect to cassandra to fetch lightcurves
+    if active >= 3:
+        lightcurve = lightcurve_fetcher(\
+            cassandra_hosts=settings.CASSANDRA_HEAD,
+            reliabilityThreshold=0.5)
+
     msl = db_connect.readonly()
     cursor = msl.cursor(buffered=True, dictionary=True)
     query_results = []
@@ -203,6 +215,21 @@ def topic_refresh(real_sql, topic, limit=10):
         cursor.execute(query)
         for record in cursor:
             recorddict = dict(record)
+
+            # fetch lightcurve from cassandra
+            if 'diaObjectId' in recorddict and active >= 3:
+                diaObjectId = recorddict['diaObjectId']
+                (diaObject, diaSourcesList, diaForcedSourcesList) = \
+                    lightcurve.fetch(diaObjectId, lite=False)
+                alert = {
+                    'diaObjectId':diaObjectId,
+                    'diaObject':diaObject,
+                    'diaSourcesList':diaSourcesList,
+                    'diaForcedSourcesList':diaForcedSourcesList}
+                if active == 3:
+                    alert = lightcurve_lite(alert)
+                recorddict['alert'] = alert
+
             query_results.append(recorddict)
     except Exception as e:
         message += "SQL error for %s: %s" % (topic, str(e))

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -130,7 +130,7 @@ def filter_query_detail(request, mq_id, action=False):
             filterQuery.topic_name = tn
             delete_stream_file(request, filterQuery.name)
             message = ''
-            if filterQuery.active == 2:
+            if filterQuery.active >= 2:
                 try:
                     message = topic_refresh(filterQuery.real_sql, tn, limit=10)
                 except Exception as e:
@@ -150,9 +150,9 @@ def filter_query_detail(request, mq_id, action=False):
         newFil.user = request.user
         newFil.name = request.POST.get('name')
         newFil.description = request.POST.get('description')
-        newFil.active = request.POST.get('active')
+        newFil.active = int(request.POST.get('active'))
         newFil.byte_query = settings.KAFKA_BYTE_QUOTA
-        newFil.topic_name = topicName(request.user.id, newFil.name)
+        newFil.topic_name = tn = topicName(request.user.id, newFil.name)
 
         if request.POST.get('public'):
             newFil.public = True
@@ -164,7 +164,15 @@ def filter_query_detail(request, mq_id, action=False):
         filterQuery = newFil
         mq_id = filterQuery.pk
 
-        messages.success(request, f'You have successfully copied the "{oldName}" filter to My Filters. The results table is initially empty, but should start to fill as new transient detections match against your filter.')
+        message = ''
+        if newFil.active >= 2:
+            try:
+                message += topic_refresh(newFil.real_sql, tn, limit=10) + '<br/>'
+            except Exception as e:
+                messages.error(request, f'The kafka topic could not be refreshed for this filter. {e}')
+
+        message += f'You have successfully copied the "{oldName}" filter to My Filters.'
+        messages.success(request, message)
         return redirect(f'filter_query_detail', mq_id)
     else:
         form = UpdateFilterQueryForm(instance=filterQuery, request=request)
@@ -411,17 +419,18 @@ def filter_query_create(request, mq_id=False):
             filterQuery.date_expire = \
                 datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
             filterQuery.save()
+            message = ''
 
             # AFTER SAVING, DELETE THE TOPIC AND PUSH SOME RECORDS FROM THE DATABASE
-            if filterQuery.active == 2:
+            if int(filterQuery.active) >= 2:
                 try:
-                    message += topic_refresh(filterQuery.real_sql, tn, limit=10)
+                    message += topic_refresh(filterQuery.real_sql, tn, limit=10) + '<br/>'
                 except Exception as e:
                     messages.error(request, f'The kafka topic could not be refreshed for this filter. {e}')
 
             filtername = form.cleaned_data.get('name')
-#            messages.success(request, f'The "{filtername}" filter has been successfully {verb}')
-            messages.success(request, message)  # hack hack
+            message += f'The "{filtername}" filter has been successfully {verb}'
+            messages.success(request, message)
             return redirect(f'filter_query_detail', filterQuery.pk)
 
     else:

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -130,9 +130,10 @@ def filter_query_detail(request, mq_id, action=False):
             filterQuery.topic_name = tn
             delete_stream_file(request, filterQuery.name)
             message = ''
-            if filterQuery.active >= 2:
+            active = int(filterQuery.active)
+            if active >= 2:
                 try:
-                    message = topic_refresh(filterQuery.real_sql, tn, limit=10)
+                    message = topic_refresh(filterQuery.real_sql, tn, active, limit=10)
                 except Exception as e:
                     messages.error(request, f'The kafka topic could not be refreshed for this filter. {e}')
             filterQuery.save()
@@ -165,9 +166,10 @@ def filter_query_detail(request, mq_id, action=False):
         mq_id = filterQuery.pk
 
         message = ''
-        if newFil.active >= 2:
+        active = int(newFil.active)
+        if active >= 2:
             try:
-                message += topic_refresh(newFil.real_sql, tn, limit=10) + '<br/>'
+                message += topic_refresh(newFil.real_sql, tn, active, limit=10) + '<br/>'
             except Exception as e:
                 messages.error(request, f'The kafka topic could not be refreshed for this filter. {e}')
 
@@ -422,9 +424,10 @@ def filter_query_create(request, mq_id=False):
             message = ''
 
             # AFTER SAVING, DELETE THE TOPIC AND PUSH SOME RECORDS FROM THE DATABASE
-            if int(filterQuery.active) >= 2:
+            active = int(filterQuery.active)
+            if active >= 2:
                 try:
-                    message += topic_refresh(filterQuery.real_sql, tn, limit=10) + '<br/>'
+                    message += topic_refresh(filterQuery.real_sql, tn, active, limit=10) + '<br/>'
                 except Exception as e:
                     messages.error(request, f'The kafka topic could not be refreshed for this filter. {e}')
 

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -151,7 +151,7 @@ def filter_query_detail(request, mq_id, action=False):
         newFil.user = request.user
         newFil.name = request.POST.get('name')
         newFil.description = request.POST.get('description')
-        newFil.active = int(request.POST.get('active'))
+        newFil.active = request.POST.get('active')
         newFil.byte_query = settings.KAFKA_BYTE_QUOTA
         newFil.topic_name = tn = topicName(request.user.id, newFil.name)
 


### PR DESCRIPTION
Each time a filter is 
- created new
- modified and saved
- duplicated
and if it produces Kafka (i.e. active=2,3,4), then the kafka topic is deleted, and a new topic created, with 10 new messages produced by running the filter on the main database. This has been verified for all 9 combinations.

- Have any tests been written to test the new code in this pull request?
  - [ ] Yes. I have added the command to run the test below.
  - [x] No. I have added the reason for the lack of testing below. 
- Have you added any new documentation for the changes in this pull-request?
  - [ ] Yes. I state below where the documentation lives.
  - [x] No. No new documentation was needed.

