### PR TITLE
Hourly TNS updates and modification of the TNS runner code

### DIFF
--- a/services/externalBrokers/TNS/fetch_from_tns.py
+++ b/services/externalBrokers/TNS/fetch_from_tns.py
@@ -31,8 +31,8 @@ def fetch_csv(date):
     os.system(cmd)
     try:
         archive = zipfile.ZipFile(filename, mode='r')
-    except:
-        print("ERROR with TNS/poll_tns: Cannot download " + cmd)
+    except Exception as e:
+        print("ERROR with TNS/poll_tns: Cannot download the CSV file.")
         sys.exit()
 
     if date == 'All':
@@ -50,7 +50,7 @@ if __name__ == '__main__':
     from datetime import datetime, timedelta
     g = datetime.now() - timedelta(days=1)
 #    yesterday = str(g).split()[0].replace('-', '')
-    hour = '09'
+    hour = '13'
     rows = fetch_csv(hour)
     #rows = fetch_csv(yesterday)
     #rows = fetch_csv('All')

--- a/services/externalBrokers/TNS/fetch_from_tns.py
+++ b/services/externalBrokers/TNS/fetch_from_tns.py
@@ -17,8 +17,15 @@ def fetch_csv(date):
 
     if date == 'All':
         cmd += settings.TNS_URL + 'tns_public_objects.csv.zip '
-    else:
+    elif len(date) == 8: # e.g. the date is 20260521
         cmd += settings.TNS_URL + 'tns_public_objects_%s.csv.zip ' % date
+    elif len(date) == 2: # This assumes the hour - e.g. 09 or 23
+        cmd += settings.TNS_URL + 'tns_public_objects_%s.csv.zip ' % date
+    else:
+        # The date is not in the right format. Panic!
+        print("ERROR with the date format.")
+        sys.exit(1)
+        
 
     cmd += ' > %s' % filename
     os.system(cmd)
@@ -42,10 +49,13 @@ def fetch_csv(date):
 if __name__ == '__main__':
     from datetime import datetime, timedelta
     g = datetime.now() - timedelta(days=1)
-    yesterday = str(g).split()[0].replace('-', '')
-    rows = fetch_csv(yesterday)
+#    yesterday = str(g).split()[0].replace('-', '')
+    hour = '09'
+    rows = fetch_csv(hour)
+    #rows = fetch_csv(yesterday)
     #rows = fetch_csv('All')
     header = rows[0]
+    print(rows)
 
     print(header)
 #    print('----')

--- a/services/externalBrokers/TNS/poll_tns.py
+++ b/services/externalBrokers/TNS/poll_tns.py
@@ -3,6 +3,7 @@
 
 Usage:
   %s [--daysAgo=<n>]
+  %s [--hourly]
   %s [--radius=3]
   %s (-h | --help)
   %s (-v | --version)
@@ -11,12 +12,13 @@ Options:
   -h --help            Show this screen.
   --daysAgo=<n>        Which nightly report to fetch. 1 day ago is default.
                        If 'All', then the whole TNS database is scrubbed and rebuilt
+  --hourly             Get the TNS data for the current hour.
   --radius=<f>         Matching radius, arcseconds, default 3
 """
 
 import sys
 sys.path.append('../../../common')
-__doc__ = __doc__ % (sys.argv[0], sys.argv[0], sys.argv[0], sys.argv[0])
+__doc__ = __doc__ % (sys.argv[0], sys.argv[0], sys.argv[0], sys.argv[0], sys.argv[0])
 from docopt import docopt
 import os, sys
 import csv
@@ -185,7 +187,7 @@ def getTNSData(opts, conn):
     if options.radius:
         radius = float(options.radius)
 
-    if options.daysAgo == 'All':
+    if options.daysAgo is not None and options.daysAgo == 'All':
         doingAll = True
         # truncate the cables crossmatch_tns, and
         #     watchlist_cones(TNS), watchlist_hits(TNS)
@@ -195,7 +197,7 @@ def getTNSData(opts, conn):
         data = fetch_csv('All')
 
 #        data = data[:10]   reduce to 10 for testing
-    else:
+    elif options.daysAgo is not None and options.daysAgo != 'All':
         doingAll = False
         try:
             daysAgo = int(options.daysAgo)
@@ -210,9 +212,19 @@ def getTNSData(opts, conn):
 
         # get the data file from TNS
         data = fetch_csv(pastTime)
+    elif options.hourly is not None:
+        # Grab the current hour.
+        hour = "%0d" % (datetime.now().hour)
+        data = fetch_csv(hour)
+    else:
+        # Panic. Wrong option combination.
+        print("Incorrect combination of options.")
+        sys.exit(1)
+
 
     # First row of the CSV is the header names
     header = data[0]
+
     rowsAdded = 0
     rowsChanged = 0
 

--- a/services/externalBrokers/TNS/poll_tns.py
+++ b/services/externalBrokers/TNS/poll_tns.py
@@ -23,7 +23,7 @@ from docopt import docopt
 import os, sys
 import csv
 from datetime import datetime
-from gkutils.commonutils import Struct, dbConnect, cleanOptions
+from gkutils.commonutils import Struct, cleanOptions
 from gkhtm import _gkhtm as htmCircle
 import tns_crossmatch
 from fetch_from_tns import fetch_csv
@@ -187,6 +187,8 @@ def getTNSData(opts, conn):
     if options.radius:
         radius = float(options.radius)
 
+    doingAll = False
+
     if options.daysAgo is not None and options.daysAgo == 'All':
         doingAll = True
         # truncate the cables crossmatch_tns, and
@@ -214,7 +216,7 @@ def getTNSData(opts, conn):
         data = fetch_csv(pastTime)
     elif options.hourly is not None:
         # Grab the current hour.
-        hour = "%0d" % (datetime.now().hour)
+        hour = "%02d" % (datetime.now() - timedelta(hours=1)).hour
         data = fetch_csv(hour)
     else:
         # Panic. Wrong option combination.
@@ -223,11 +225,16 @@ def getTNSData(opts, conn):
 
 
     # First row of the CSV is the header names
+    if len(data) == 0:
+        print("No data and no header.")
+        sys.exit(1)
+
     header = data[0]
 
     rowsAdded = 0
     rowsChanged = 0
 
+    #print("Data length = ", len(data))
     for row in data[1:]:
         row_dict = {}
         for i in range(len(header)):
@@ -291,6 +298,7 @@ if __name__ == '__main__':
     conn = db_connect.remote()
     options = Struct(**opts)
 
+ 
     getTNSData(options, conn)
 
     countTNS = countTNSRow(conn)

--- a/services/externalBrokers/TNS/tns_runner.py
+++ b/services/externalBrokers/TNS/tns_runner.py
@@ -1,10 +1,30 @@
 #!/usr/bin/env python
-"""
-Run the TNS refresher, putting logs where Lasair can see them
+"""Wrapper for the TNS refresher, putting logs where Lasair can see them.
+
+Usage:
+  %s [--daysAgo=<n>] [--hourly] [--radius=<f>]
+  %s (-h | --help)
+  %s --version
+
+Options:
+  -h --help            Show this screen.
+  --version            Show version.
+  --daysAgo=<n>        Which nightly report to fetch. 1 day ago is default.
+                       If 'All', then the whole TNS database is scrubbed and rebuilt
+  --hourly             Get the TNS data for the current hour.
+  --radius=<f>         Matching radius, arcseconds, default 3
+
+
+E.g.:
+  %s --daysAgo=1
+  %s --hourly
+  %s --hourly --radius=5
 """
 
 import os,sys, time
 sys.path.append('../../../common')
+__doc__ = __doc__ % (sys.argv[0], sys.argv[0], sys.argv[0], sys.argv[0], sys.argv[0], sys.argv[0])
+from gkutils.commonutils import cleanOptions
 import settings
 from src import date_nid
 import datetime
@@ -13,12 +33,18 @@ sys.path.append('../..')
 from my_cmd import execute_cmd
 import slack_webhook
 import lasairLogging
+from docopt import docopt
 
 def now():
     # current UTC as string
     return datetime.datetime.now(datetime.UTC).strftime("%Y/%m/%dT%H:%M:%S")
 
 if __name__ == "__main__":
+    opts = docopt(__doc__, version='0.1')
+    opts = cleanOptions(opts)
+
+    # Leave the options as a dict. Easier to handle below.
+
     slack_channel = getattr(settings, 'SLACK_CHANNEL', None)
     lasairLogging.basicConfig(
         filename='/home/ubuntu/logs/svc.log',
@@ -34,6 +60,13 @@ if __name__ == "__main__":
 
     cmd = 'echo "\\n-- poll_tns at %s"' % now()
     execute_cmd(cmd, logfile)
+    
+    arguments = ''
+    for k, v in opts.items():
+        if v and type(v) is not bool:
+            arguments += '--%s=%s ' % (k,v)
+        if v and type(v) is bool:
+            arguments += '--%s ' % (k)
 
-    cmd = 'python3 poll_tns.py --daysAgo=1'
+    cmd = 'python3 poll_tns.py ' + arguments
     execute_cmd(cmd, logfile)


### PR DESCRIPTION

# CHECKLIST

- Have any tests been written to test the new code in this pull request?
  - [ ] Yes. I have added the command to run the test below.
  - [X] No. I have added the reason for the lack of testing below. 
- Have you added any new documentation for the changes in this pull-request?
  - [ ] Yes. I state below where the documentation lives.
  - [X] No. No new documentation was needed.

# NOTES
No actual tests have been written as such, except that it's running in dev. Happy to work with someone to get some tests organised.

The crontab entry for this code on the server shoud look something like this:
```
# Poll full TNS Mon and Thurs at 09:15
15 9 * * 1,4 (cd /home/ubuntu/lasair-lsst/services/externalBrokers/TNS; /opt/lasair_venv/bin/python3 tns_runner.py --daysAgo=All)
# Poll TNS every day 08:10
10 8 * * * (cd /home/ubuntu/lasair-lsst/services/externalBrokers/TNS; /opt/lasair_venv/bin/python3 tns_runner.py --daysAgo=1)
# Poll TNS every day hour (at 30 mins past the hour) for the PREVIOUS hour's data between midnight and 1700.
30 0-17,23 * * * (cd /home/ubuntu/lasair-lsst/services/externalBrokers/TNS; /opt/lasair_venv/bin/python3 tns_runner.py --hourly)
# Dump crossmatch_tns
0 22 * * * (cd /home/ubuntu/lasair-lsst/services; /opt/lasair_venv/bin/python3 crossmatch_tns_dump.py)
```

# CHANGES
- `poll_tns.py` hourly option now checks for the *previous* hour
- `tns_runner.py` now has a docopt style header to allow parameters to be passed to it, and therefore onwards to `poll_tns.py`.  (I'm not convinced that this is the best way to do this - I suspect `tns_runner.py` and `poll_tns.py` should be combined.

