### PR TITLE
Schema 11 1

### DIFF
--- a/common/schema/11_1/annotations.py
+++ b/common/schema/11_1/annotations.py
@@ -1,0 +1,62 @@
+schema = {
+  "name": "annotations",
+  "version": "1.0",
+  "fields": [
+    {
+      "name": "annotationID",
+      "type": "int",
+      "extra": "NOT NULL AUTO_INCREMENT",
+      "doc": "auto increment counter"
+    },
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "extra": "NOT NULL",
+      "doc": "ObjectId of the object that this annotator applies to"
+    },
+    {
+      "name": "topic",
+      "type": "text",
+      "doc": "The topic name of the annotator -- acts as primary key"
+    },
+    {
+      "name": "version",
+      "type": "bigstring",
+      "default": "0.1",
+      "doc": "Version information for the annotator software"
+    },
+    {
+      "name": "timestamp",
+      "type": "timestamp",
+      "extra": "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+      "doc": "Time at which this annotation was added to the database"
+    },
+    {
+      "name": "classification",
+      "type": "bigstring",
+      "extra": "NOT NULL",
+      "doc": "Short, non-trivial string expressing the classification of this object by this annotator"
+    },
+    {
+      "name": "explanation",
+      "type": "text",
+      "doc": "Natural language explanation of the classification"
+    },
+    {
+      "name": "classdict",
+      "type": "JSON",
+      "doc": "Machine readable informayion about the classification"
+    },
+    {
+      "name": "url",
+      "type": "text",
+      "default": "NULL",
+      "doc": "URL for further information about this annotation of this object"
+    }
+  ],
+  "indexes": [
+    "PRIMARY KEY    (annotationID)",
+    "UNIQUE KEY     one_per_object (diaObjectId, topic)",
+    "KEY topic_idx (topic)"
+  ]
+}

--- a/common/schema/11_1/area_hits.py
+++ b/common/schema/11_1/area_hits.py
@@ -1,0 +1,19 @@
+schema = {
+  "name": "area_hits",
+  "version": "1.0",
+  "fields": [
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "doc": "ZTF object identifier"
+    },
+    {
+      "name": "ar_id",
+      "type": "int",
+      "doc": "Area identifier"
+    }
+  ],
+  "indexes": [
+    "PRIMARY KEY (`diaObjectId`)"
+  ]
+}

--- a/common/schema/11_1/crossmatch_tns.py
+++ b/common/schema/11_1/crossmatch_tns.py
@@ -1,0 +1,111 @@
+schema = {
+  "name": "crossmatch_tns",
+  "version": "1.0",
+  "fields": [
+    {
+      "name": "ra",
+      "type": "double",
+      "doc": "Right ascension in decimal degrees"
+    },
+    {
+      "name": "decl",
+      "type": "double",
+      "doc": "Declination in decimal degrees"
+    },
+    {
+      "name": "tns_name",
+      "type": "string",
+      "doc": "TNS name, for example 2021iru"
+    },
+    {
+      "name": "tns_prefix",
+      "type": "string",
+      "doc": "For example SN or AT"
+    },
+    {
+      "name": "disc_mag",
+      "type": "float",
+      "doc": "Discovery magnitude"
+    },
+    {
+      "name": "disc_mag_filter",
+      "type": "string",
+      "doc": "string"
+    },
+    {
+      "name": "type",
+      "type": "bigstring",
+      "doc": "Astrophysical type of supernova, eg SN Ia"
+    },
+    {
+      "name": "z",
+      "type": "float",
+      "doc": "Redshift"
+    },
+    {
+      "name": "hostz",
+      "type": "float",
+      "doc": "Redshift of host galaxy",
+      "default": "NULL"
+    },
+    {
+      "name": "host_name",
+      "type": "bigstring",
+      "doc": "Name of host galaxy",
+      "default": "NULL"
+    },
+    {
+      "name": "ext_catalogs",
+      "type": "bigstring",
+      "doc": "External catalogues used",
+      "default": "NULL"
+    },
+    {
+      "name": "disc_int_name",
+      "type": "bigstring",
+      "doc": "Discoverers internal name"
+    },
+    {
+      "name": "disc_date",
+      "type": "date",
+      "doc": "Discovery date"
+    },
+    {
+      "name": "lastmodified_date",
+      "type": "date",
+      "doc": "Last Modified date"
+    },
+    {
+      "name": "sender",
+      "type": "string",
+      "doc": "Discoverers internal name"
+    },
+    {
+      "name": "reporters",
+      "type": "bigstring",
+      "doc": "Discoverers internal name"
+    },
+    {
+      "name": "source_group",
+      "type": "string",
+      "doc": "Discoverers internal name"
+    },
+    {
+      "name": "htm16",
+      "type": "bigint",
+      "doc": "Hierarchical Triangular Mesh level 16"
+    },
+    {
+      "name": "lasairmodified_date",
+      "type": "timestamp",
+      "extra": "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+      "doc": "Lasair last Modified date"
+    }
+  ],
+  "indexes": [
+    "id int(10) unsigned NOT NULL AUTO_INCREMENT",
+    "PRIMARY KEY (`id`)",
+    "KEY `idx_htm16` (`htm16`)",
+    "KEY tns_name_idx (tns_name)"
+  ]
+}

--- a/common/schema/11_1/cutouts.py
+++ b/common/schema/11_1/cutouts.py
@@ -1,0 +1,28 @@
+schema = {
+  "name": "cutouts",
+  "fields": [
+    {
+      "name": "cutoutId",
+      "type": "char"
+    },
+    {
+      "name": "objectId",
+      "type": "bigint"
+    },
+    {
+      "name": "isDiaObject",
+      "type": "boolean"
+    },
+    {
+      "name": "cutoutimage",
+      "type": "blob"
+    }
+  ],
+  "indexes": ['PRIMARY KEY ("cutoutId")'],
+  "with": """WITH compaction=
+{'class': 'org.apache.cassandra.db.compaction.TimeWindowCompactionStrategy', 
+'compaction_window_size': '7', 
+'compaction_window_unit': 'DAYS'}
+AND default_time_to_live=31536000
+"""
+}

--- a/common/schema/11_1/cutoutsByObject.py
+++ b/common/schema/11_1/cutoutsByObject.py
@@ -1,0 +1,18 @@
+schema = {
+  "name": "cutoutsbyObject",
+  "fields": [
+    {
+      "name": "objectId",
+      "type": "bigint"
+    },
+        {
+      "name": "isDiaObject",
+      "type": "boolean"
+    },
+    {
+      "name": "cutoutId",
+      "type": "char"
+    },
+  ],
+  "indexes": ['PRIMARY KEY ("objectId", "cutoutId")']
+}

--- a/common/schema/11_1/diaForcedSources.py
+++ b/common/schema/11_1/diaForcedSources.py
@@ -1,0 +1,76 @@
+schema = {
+  'indexes':['PRIMARY KEY ("diaObjectId","midpointMjdTai")'],
+  "name": "diaForcedSources",
+  "fields": [
+    {
+      "name": "diaForcedSourceId",
+      "type": "long",
+      "doc": "Unique id."
+    },
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "doc": "Id of the DiaObject that this DiaForcedSource was associated with."
+    },
+    {
+      "name": "ra",
+      "type": "double",
+      "doc": "Right ascension coordinate of the position of the DiaObject [deg]."
+    },
+    {
+      "name": "decl",
+      "type": "double",
+      "doc": "Declination coordinate of the position of the DiaObject [deg]."
+    },
+    {
+      "name": "visit",
+      "type": "long",
+      "doc": "Id of the visit where this forcedSource was measured."
+    },
+    {
+      "name": "detector",
+      "type": "int",
+      "doc": "Id of the detector where this forcedSource was measured. Datatype short instead of byte because of DB concerns about unsigned bytes."
+    },
+    {
+      "name": "psfFlux",
+      "type": "float",
+      "doc": "Point Source model flux [nJy]."
+    },
+    {
+      "name": "psfFluxErr",
+      "type": "float",
+      "doc": "Uncertainty of psfFlux [nJy]."
+    },
+    {
+      "name": "midpointMjdTai",
+      "type": "double",
+      "doc": "Effective mid-visit time for this diaForcedSource, expressed as Modified Julian Date, International Atomic Time [d]."
+    },
+    {
+      "name": "scienceFlux",
+      "type": "float",
+      "doc": "Forced photometry flux for a point source model measured on the visit image centered at the DiaObject position [nJy]."
+    },
+    {
+      "name": "scienceFluxErr",
+      "type": "float",
+      "doc": "Uncertainty of scienceFlux [nJy]."
+    },
+    {
+      "name": "band",
+      "type": "string",
+      "doc": "Filter band this source was observed with."
+    },
+    {
+      "name": "timeProcessedMjdTai",
+      "type": "double",
+      "doc": "Time when this record was generated, expressed as Modified Julian Date, International Atomic Time."
+    },
+    {
+      "name": "timeWithdrawnMjdTai",
+      "type": "double",
+      "doc": "Time when this record was marked invalid, expressed as Modified Julian Date, International Atomic Time."
+    }
+  ]
+}

--- a/common/schema/11_1/diaNondetectionLimits.py
+++ b/common/schema/11_1/diaNondetectionLimits.py
@@ -1,0 +1,76 @@
+schema = {
+  'indexes':['PRIMARY KEY ("midpointMjdTai")'],
+  "name": "diaForcedSources",
+  "fields": [
+    {
+      "name": "diaForcedSourceId",
+      "type": "long",
+      "doc": "Unique id."
+    },
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "doc": "Id of the DiaObject that this DiaForcedSource was associated with."
+    },
+    {
+      "name": "ra",
+      "type": "double",
+      "doc": "Right ascension coordinate of the position of the DiaObject [deg]."
+    },
+    {
+      "name": "decl",
+      "type": "double",
+      "doc": "Declination coordinate of the position of the DiaObject [deg]."
+    },
+    {
+      "name": "visit",
+      "type": "long",
+      "doc": "Id of the visit where this forcedSource was measured."
+    },
+    {
+      "name": "detector",
+      "type": "int",
+      "doc": "Id of the detector where this forcedSource was measured. Datatype short instead of byte because of DB concerns about unsigned bytes."
+    },
+    {
+      "name": "psfFlux",
+      "type": "float",
+      "doc": "Point Source model flux [nJy]."
+    },
+    {
+      "name": "psfFluxErr",
+      "type": "float",
+      "doc": "Uncertainty of psfFlux [nJy]."
+    },
+    {
+      "name": "midpointMjdTai",
+      "type": "double",
+      "doc": "Effective mid-visit time for this diaForcedSource, expressed as Modified Julian Date, International Atomic Time [d]."
+    },
+    {
+      "name": "scienceFlux",
+      "type": "float",
+      "doc": "Forced photometry flux for a point source model measured on the visit image centered at the DiaObject position [nJy]."
+    },
+    {
+      "name": "scienceFluxErr",
+      "type": "float",
+      "doc": "Uncertainty of scienceFlux [nJy]."
+    },
+    {
+      "name": "band",
+      "type": "string",
+      "doc": "Filter band this source was observed with."
+    },
+    {
+      "name": "timeProcessedMjdTai",
+      "type": "double",
+      "doc": "Time when this record was generated, expressed as Modified Julian Date, International Atomic Time."
+    },
+    {
+      "name": "timeWithdrawnMjdTai",
+      "type": "double",
+      "doc": "Time when this record was marked invalid, expressed as Modified Julian Date, International Atomic Time."
+    }
+  ]
+}

--- a/common/schema/11_1/diaObjects.py
+++ b/common/schema/11_1/diaObjects.py
@@ -1,0 +1,416 @@
+schema = {
+  'indexes':['PRIMARY KEY ("diaObjectId")'],
+  "name": "diaObjects",
+  "fields": [
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "doc": "Unique identifier of this DiaObject."
+    },
+    {
+      "name": "validityStartMjdTai",
+      "type": "double",
+      "doc": "Processing time when validity of this diaObject starts, expressed as Modified Julian Date, International Atomic Time."
+    },
+    {
+      "name": "ra",
+      "type": "double",
+      "doc": "Right ascension coordinate of the position of the object [deg]."
+    },
+    {
+      "name": "raErr",
+      "type": "float",
+      "doc": "Angular error of Right Ascension (\u2202RA*cos(Dec)) [deg]."
+    },
+    {
+      "name": "decl",
+      "type": "double",
+      "doc": "Declination coordinate of the position of the object [deg]."
+    },
+    {
+      "name": "decErr",
+      "type": "float",
+      "doc": "Angular error of dec [deg]."
+    },
+    {
+      "name": "ra_dec_Cov",
+      "type": "float",
+      "doc": "Covariance between Right Ascension (RA*cos(Dec)) and dec [deg**2]."
+    },
+    {
+      "name": "u_psfFluxMean",
+      "type": "float",
+      "doc": "Weighted mean point-source model magnitude for u filter [nJy]."
+    },
+    {
+      "name": "u_psfFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of u_psfFluxMean [nJy]."
+    },
+    {
+      "name": "u_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of u_psfFlux [nJy]."
+    },
+    {
+      "name": "u_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of u-band data points."
+    },
+    {
+      "name": "u_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for u filter [nJy]."
+    },
+    {
+      "name": "u_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of u_fpFluxMean [nJy]."
+    },
+    {
+      "name": "g_psfFluxMean",
+      "type": "float",
+      "doc": "Weighted mean point-source model magnitude for g filter [nJy]."
+    },
+    {
+      "name": "g_psfFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of g_psfFluxMean [nJy]."
+    },
+    {
+      "name": "g_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of g_psfFlux [nJy]."
+    },
+    {
+      "name": "g_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of g-band data points."
+    },
+    {
+      "name": "g_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for g filter [nJy]."
+    },
+    {
+      "name": "g_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of g_fpFluxMean [nJy]."
+    },
+    {
+      "name": "r_psfFluxMean",
+      "type": "float",
+      "doc": "Weighted mean point-source model magnitude for r filter [nJy]."
+    },
+    {
+      "name": "r_psfFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of r_psfFluxMean [nJy]."
+    },
+    {
+      "name": "r_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of r_psfFlux [nJy]."
+    },
+    {
+      "name": "r_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of r-band data points."
+    },
+    {
+      "name": "r_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for r filter [nJy]."
+    },
+    {
+      "name": "r_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of r_fpFluxMean [nJy]."
+    },
+    {
+      "name": "i_psfFluxMean",
+      "type": "float",
+      "doc": "Weighted mean point-source model magnitude for i filter [nJy]."
+    },
+    {
+      "name": "i_psfFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of i_psfFluxMean [nJy]."
+    },
+    {
+      "name": "i_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of i_psfFlux [nJy]."
+    },
+    {
+      "name": "i_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of i-band data points."
+    },
+    {
+      "name": "i_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for i filter [nJy]."
+    },
+    {
+      "name": "i_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of i_fpFluxMean [nJy]."
+    },
+    {
+      "name": "z_psfFluxMean",
+      "type": "float",
+      "doc": "Weighted mean point-source model magnitude for z filter [nJy]."
+    },
+    {
+      "name": "z_psfFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of z_psfFluxMean [nJy]."
+    },
+    {
+      "name": "z_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of z_psfFlux [nJy]."
+    },
+    {
+      "name": "z_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of z-band data points."
+    },
+    {
+      "name": "z_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for z filter [nJy]."
+    },
+    {
+      "name": "z_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of z_fpFluxMean [nJy]."
+    },
+    {
+      "name": "y_psfFluxMean",
+      "type": "float",
+      "doc": "Weighted mean point-source model magnitude for y filter [nJy]."
+    },
+    {
+      "name": "y_psfFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of y_psfFluxMean [nJy]."
+    },
+    {
+      "name": "y_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of y_psfFlux [nJy]."
+    },
+    {
+      "name": "y_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of y-band data points."
+    },
+    {
+      "name": "y_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for y filter [nJy]."
+    },
+    {
+      "name": "y_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of y_fpFluxMean [nJy]."
+    },
+    {
+      "name": "u_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for u filter [nJy]."
+    },
+    {
+      "name": "u_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of u_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "g_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for g filter [nJy]."
+    },
+    {
+      "name": "g_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of g_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "r_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for r filter [nJy]."
+    },
+    {
+      "name": "r_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of r_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "i_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for i filter [nJy]."
+    },
+    {
+      "name": "i_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of i_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "z_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for z filter [nJy]."
+    },
+    {
+      "name": "z_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of z_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "y_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for y filter [nJy]."
+    },
+    {
+      "name": "y_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of y_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "u_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed u band fluxes [nJy]."
+    },
+    {
+      "name": "u_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed u band fluxes [nJy]."
+    },
+    {
+      "name": "u_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between u band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "u_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the u band flux errors [nJy]."
+    },
+    {
+      "name": "g_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed g band fluxes [nJy]."
+    },
+    {
+      "name": "g_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed g band fluxes [nJy]."
+    },
+    {
+      "name": "g_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between g band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "g_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the g band flux errors [nJy]."
+    },
+    {
+      "name": "r_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed r band fluxes [nJy]."
+    },
+    {
+      "name": "r_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed r band fluxes [nJy]."
+    },
+    {
+      "name": "r_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between r band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "r_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the r band flux errors [nJy]."
+    },
+    {
+      "name": "i_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed i band fluxes [nJy]."
+    },
+    {
+      "name": "i_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed i band fluxes [nJy]."
+    },
+    {
+      "name": "i_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between i band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "i_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the i band flux errors [nJy]."
+    },
+    {
+      "name": "z_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed z band fluxes [nJy]."
+    },
+    {
+      "name": "z_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed z band fluxes [nJy]."
+    },
+    {
+      "name": "z_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between z band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "z_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the z band flux errors [nJy]."
+    },
+    {
+      "name": "y_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed y band fluxes [nJy]."
+    },
+    {
+      "name": "y_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed y band fluxes [nJy]."
+    },
+    {
+      "name": "y_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between y band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "y_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the y band flux errors [nJy]."
+    },
+    {
+      "name": "firstDiaSourceMjdTai",
+      "type": "double",
+      "doc": "Time of the first diaSource, expressed as Modified Julian Date, International Atomic Time."
+    },
+    {
+      "name": "lastDiaSourceMjdTai",
+      "type": "double",
+      "doc": "Time of the most recent non-forced DIASource for this object, expressed as Modified Julian Date, International Atomic Time."
+    },
+    {
+      "name": "nDiaSources",
+      "type": "int",
+      "doc": "Total number of DiaSources associated with this DiaObject."
+    }
+  ]
+}

--- a/common/schema/11_1/diaSources.py
+++ b/common/schema/11_1/diaSources.py
@@ -1,0 +1,516 @@
+schema = {
+  'indexes':['PRIMARY KEY ("diaObjectId", "midpointMjdTai", "diaSourceId")'],
+  "name": "diaSources",
+  "fields": [
+    {
+      "name": "diaSourceId",
+      "type": "long",
+      "doc": "Unique identifier of this DiaSource."
+    },
+    {
+      "name": "visit",
+      "type": "long",
+      "doc": "Id of the visit where this diaSource was measured."
+    },
+    {
+      "name": "detector",
+      "type": "int",
+      "doc": "Id of the detector where this diaSource was measured. Datatype short instead of byte because of DB concerns about unsigned bytes."
+    },
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "doc": "Id of the diaObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject)."
+    },
+    {
+      "name": "ssObjectId",
+      "type": "long",
+      "doc": "Id of the ssObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject)."
+    },
+    {
+      "name": "parentDiaSourceId",
+      "type": "long",
+      "doc": "Id of the parent diaSource this diaSource has been deblended from, if any."
+    },
+    {
+      "name": "midpointMjdTai",
+      "type": "double",
+      "doc": "Effective mid-visit time for this diaSource, expressed as Modified Julian Date, International Atomic Time [d]."
+    },
+    {
+      "name": "exposureTime",
+      "type": "float",
+      "doc": "Effective exposure time for this diaSource [s]."
+    },
+    {
+      "name": "ra",
+      "type": "double",
+      "doc": "Right ascension coordinate of the center of this diaSource [deg]."
+    },
+    {
+      "name": "raErr",
+      "type": "float",
+      "doc": "Angular error of Right Ascension (\u2202RA*cos(Dec)) [deg]."
+    },
+    {
+      "name": "decl",
+      "type": "double",
+      "doc": "Declination coordinate of the center of this diaSource [deg]."
+    },
+    {
+      "name": "decErr",
+      "type": "float",
+      "doc": "Angular error of dec [deg]."
+    },
+    {
+      "name": "ra_dec_Cov",
+      "type": "float",
+      "doc": "Covariance between Right Ascension (RA*cos(Dec)) and dec [deg**2]."
+    },
+    {
+      "name": "x",
+      "type": "float",
+      "doc": "x position computed by a centroiding algorithm [pixel]."
+    },
+    {
+      "name": "xErr",
+      "type": "float",
+      "doc": "Uncertainty of x [pixel]."
+    },
+    {
+      "name": "y",
+      "type": "float",
+      "doc": "y position computed by a centroiding algorithm [pixel]."
+    },
+    {
+      "name": "yErr",
+      "type": "float",
+      "doc": "Uncertainty of y [pixel]."
+    },
+    {
+      "name": "centroid_flag",
+      "type": "boolean",
+      "doc": "General centroid algorithm failure flag; set if anything went wrong when fitting the centroid. Another centroid flag field should also be set to provide more information."
+    },
+    {
+      "name": "apFlux",
+      "type": "float",
+      "doc": "Flux in a 12 pixel radius aperture on the difference image [nJy]."
+    },
+    {
+      "name": "apFluxErr",
+      "type": "float",
+      "doc": "Estimated uncertainty of apFlux [nJy]."
+    },
+    {
+      "name": "apFlux_flag",
+      "type": "boolean",
+      "doc": "General aperture flux algorithm failure flag; set if anything went wrong when measuring aperture fluxes. Another apFlux flag field should also be set to provide more information."
+    },
+    {
+      "name": "apFlux_flag_apertureTruncated",
+      "type": "boolean",
+      "doc": "Aperture did not fit within measurement image."
+    },
+    {
+      "name": "isNegative",
+      "type": "boolean",
+      "doc": "Source was detected as significantly negative."
+    },
+    {
+      "name": "snr",
+      "type": "float",
+      "doc": "The signal-to-noise ratio at which this source was detected in the difference image."
+    },
+    {
+      "name": "psfFlux",
+      "type": "float",
+      "doc": "Flux for Point Source model. Note this actually measures the flux difference between the template and the visit image [nJy]."
+    },
+    {
+      "name": "psfFluxErr",
+      "type": "float",
+      "doc": "Uncertainty of psfFlux [nJy]."
+    },
+    {
+      "name": "psfLnL",
+      "type": "float",
+      "doc": "Natural log likelihood of the observed data given the point source model."
+    },
+    {
+      "name": "psfChi2",
+      "type": "float",
+      "doc": "Chi^2 statistic of the point source model fit."
+    },
+    {
+      "name": "psfNdata",
+      "type": "int",
+      "doc": "The number of data points (pixels) used to fit the point source model."
+    },
+    {
+      "name": "psfFlux_flag",
+      "type": "boolean",
+      "doc": "Failure to derive linear least-squares fit of psf model. Another psfFlux flag field should also be set to provide more information."
+    },
+    {
+      "name": "psfFlux_flag_edge",
+      "type": "boolean",
+      "doc": "Object was too close to the edge of the image to use the full PSF model."
+    },
+    {
+      "name": "psfFlux_flag_noGoodPixels",
+      "type": "boolean",
+      "doc": "Not enough non-rejected pixels in data to attempt the fit."
+    },
+    {
+      "name": "trailFlux",
+      "type": "float",
+      "doc": "Flux for a trailed source model. Note this actually measures the flux difference between the template and the visit image [nJy]."
+    },
+    {
+      "name": "trailFluxErr",
+      "type": "float",
+      "doc": "Uncertainty of trailFlux [nJy]."
+    },
+    {
+      "name": "trailRa",
+      "type": "double",
+      "doc": "Right ascension coordinate of centroid for trailed source model [deg]."
+    },
+    {
+      "name": "trailRaErr",
+      "type": "float",
+      "doc": "Angular error of trailRa (\u2202RA*cos(Dec)) [deg]."
+    },
+    {
+      "name": "trailDec",
+      "type": "double",
+      "doc": "Declination coordinate of centroid for trailed source model [deg]."
+    },
+    {
+      "name": "trailDecErr",
+      "type": "float",
+      "doc": "Angular error of trailDec [deg]."
+    },
+    {
+      "name": "trailLength",
+      "type": "float",
+      "doc": "Maximum likelihood fit of trail length [arcsec]."
+    },
+    {
+      "name": "trailLengthErr",
+      "type": "float",
+      "doc": "Uncertainty of trailLength [arcsec]."
+    },
+    {
+      "name": "trailAngle",
+      "type": "float",
+      "doc": "Maximum likelihood fit of the angle between the meridian through the centroid and the trail direction (bearing) [deg]."
+    },
+    {
+      "name": "trailAngleErr",
+      "type": "float",
+      "doc": "Uncertainty of trailAngle [deg]."
+    },
+    {
+      "name": "trailChi2",
+      "type": "float",
+      "doc": "Chi^2 statistic of the trailed source model fit."
+    },
+    {
+      "name": "trailNdata",
+      "type": "int",
+      "doc": "The number of data points (pixels) used to fit the trailed source model."
+    },
+    {
+      "name": "trailAlgorithm",
+      "type": "int",
+      "doc": "Integer key indicating which algorithm was used to measure trailed source. 1=SDSSShape, 2=HSMShape."
+    },
+    {
+      "name": "trail_flag_edge",
+      "type": "boolean",
+      "doc": "This flag is set if a trailed source extends onto or past edge pixels."
+    },
+    {
+      "name": "trail_flag",
+      "type": "boolean",
+      "doc": "The trailed source fitting algorithm failed."
+    },
+    {
+      "name": "dipoleMeanFlux",
+      "type": "float",
+      "doc": "Maximum likelihood value for the mean absolute flux of the two lobes for a dipole model [nJy]."
+    },
+    {
+      "name": "dipoleMeanFluxErr",
+      "type": "float",
+      "doc": "Uncertainty of dipoleMeanFlux [nJy]."
+    },
+    {
+      "name": "dipoleFluxDiff",
+      "type": "float",
+      "doc": "Maximum likelihood value for the difference of absolute fluxes of the two lobes for a dipole model [nJy]."
+    },
+    {
+      "name": "dipoleFluxDiffErr",
+      "type": "float",
+      "doc": "Uncertainty of dipoleFluxDiff [nJy]."
+    },
+    {
+      "name": "dipoleLength",
+      "type": "float",
+      "doc": "Maximum likelihood value for the lobe separation in dipole model [arcsec]."
+    },
+    {
+      "name": "dipoleAngle",
+      "type": "float",
+      "doc": "Maximum likelihood fit of the angle between the meridian through the centroid and the dipole direction (bearing, from negative to positive lobe) [deg]."
+    },
+    {
+      "name": "dipoleChi2",
+      "type": "float",
+      "doc": "Chi^2 statistic of the model fit."
+    },
+    {
+      "name": "dipoleNdata",
+      "type": "int",
+      "doc": "The number of data points (pixels) used to fit the model."
+    },
+    {
+      "name": "scienceFlux",
+      "type": "float",
+      "doc": "Forced photometry flux for a point source model measured on the visit image centered at DiaSource position [nJy]."
+    },
+    {
+      "name": "scienceFluxErr",
+      "type": "float",
+      "doc": "Estimated uncertainty of scienceFlux [nJy]."
+    },
+    {
+      "name": "forced_PsfFlux_flag",
+      "type": "boolean",
+      "doc": "Forced PSF photometry on science image failed. Another forced_PsfFlux flag field should also be set to provide more information."
+    },
+    {
+      "name": "forced_PsfFlux_flag_edge",
+      "type": "boolean",
+      "doc": "Forced PSF flux on science image was too close to the edge of the image to use the full PSF model."
+    },
+    {
+      "name": "forced_PsfFlux_flag_noGoodPixels",
+      "type": "boolean",
+      "doc": "Forced PSF flux not enough non-rejected pixels in data to attempt the fit."
+    },
+    {
+      "name": "templateFlux",
+      "type": "float",
+      "doc": "Forced photometry flux for a point source model measured on the template image centered at the DiaObject position [nJy]."
+    },
+    {
+      "name": "templateFluxErr",
+      "type": "float",
+      "doc": "Uncertainty of templateFlux [nJy]."
+    },
+    {
+      "name": "ixx",
+      "type": "float",
+      "doc": "Adaptive second moment of the source intensity [arcsec**2]."
+    },
+    {
+      "name": "iyy",
+      "type": "float",
+      "doc": "Adaptive second moment of the source intensity [arcsec**2]."
+    },
+    {
+      "name": "ixy",
+      "type": "float",
+      "doc": "Adaptive second moment of the source intensity [arcsec**2]."
+    },
+    {
+      "name": "ixxPSF",
+      "type": "float",
+      "doc": "Adaptive second moment for the PSF [arcsec**2]."
+    },
+    {
+      "name": "iyyPSF",
+      "type": "float",
+      "doc": "Adaptive second moment for the PSF [arcsec**2]."
+    },
+    {
+      "name": "ixyPSF",
+      "type": "float",
+      "doc": "Adaptive second moment for the PSF [arcsec**2]."
+    },
+    {
+      "name": "shape_flag",
+      "type": "boolean",
+      "doc": "General source shape algorithm failure flag; set if anything went wrong when measuring the shape. Another shape flag field should also be set to provide more information."
+    },
+    {
+      "name": "shape_flag_no_pixels",
+      "type": "boolean",
+      "doc": "No pixels to measure shape."
+    },
+    {
+      "name": "shape_flag_not_contained",
+      "type": "boolean",
+      "doc": "Center not contained in footprint bounding box."
+    },
+    {
+      "name": "shape_flag_parent_source",
+      "type": "boolean",
+      "doc": "This source is a parent source; we should only be measuring on deblended children in difference imaging."
+    },
+    {
+      "name": "extendedness",
+      "type": "float",
+      "doc": "A measure of extendedness, computed by comparing an object's moment-based traced radius to the PSF moments. extendedness = 1 implies a high degree of confidence that the source is extended. extendedness = 0 implies a high degree of confidence that the source is point-like."
+    },
+    {
+      "name": "reliability",
+      "type": "float",
+      "doc": "Probability (0-1) that the diaSource is astrophysical, derived from a machine learning model."
+    },
+    {
+      "name": "reliabilityVersion",
+      "type": "string",
+      "doc": "Version of the reliability model."
+    },
+    {
+      "name": "band",
+      "type": "string",
+      "doc": "Filter band this source was observed with."
+    },
+    {
+      "name": "isDipole",
+      "type": "boolean",
+      "doc": "Source well fit by a dipole."
+    },
+    {
+      "name": "dipoleFitAttempted",
+      "type": "boolean",
+      "doc": "Attempted to fit a dipole model to this source."
+    },
+    {
+      "name": "timeProcessedMjdTai",
+      "type": "double",
+      "doc": "Time when the image was processed and this DiaSource record was generated, expressed as Modified Julian Date, International Atomic Time."
+    },
+    {
+      "name": "timeWithdrawnMjdTai",
+      "type": "double",
+      "doc": "Time when this record was marked invalid, expressed as Modified Julian Date, International Atomic Time."
+    },
+    {
+      "name": "bboxSize",
+      "type": "int",
+      "doc": "Size of the square bounding box that fully contains the detection footprint [pixel]."
+    },
+    {
+      "name": "pixelFlags",
+      "type": "boolean",
+      "doc": "General pixel flags failure; set if anything went wrong when setting pixels flags from this footprint's mask. This implies that some pixelFlags for this source may be incorrectly set to False."
+    },
+    {
+      "name": "pixelFlags_bad",
+      "type": "boolean",
+      "doc": "Bad pixel in the DiaSource footprint."
+    },
+    {
+      "name": "pixelFlags_cr",
+      "type": "boolean",
+      "doc": "Cosmic ray in the DiaSource footprint."
+    },
+    {
+      "name": "pixelFlags_crCenter",
+      "type": "boolean",
+      "doc": "Cosmic ray in the 3x3 region around the centroid."
+    },
+    {
+      "name": "pixelFlags_edge",
+      "type": "boolean",
+      "doc": "Some of the source footprint is outside usable exposure region (masked EDGE or centroid off image)."
+    },
+    {
+      "name": "pixelFlags_nodata",
+      "type": "boolean",
+      "doc": "NO_DATA pixel in the source footprint."
+    },
+    {
+      "name": "pixelFlags_nodataCenter",
+      "type": "boolean",
+      "doc": "NO_DATA pixel in the 3x3 region around the centroid."
+    },
+    {
+      "name": "pixelFlags_interpolated",
+      "type": "boolean",
+      "doc": "Interpolated pixel in the DiaSource footprint."
+    },
+    {
+      "name": "pixelFlags_interpolatedCenter",
+      "type": "boolean",
+      "doc": "Interpolated pixel in the 3x3 region around the centroid."
+    },
+    {
+      "name": "pixelFlags_offimage",
+      "type": "boolean",
+      "doc": "DiaSource center is off image."
+    },
+    {
+      "name": "pixelFlags_saturated",
+      "type": "boolean",
+      "doc": "Saturated pixel in the DiaSource footprint."
+    },
+    {
+      "name": "pixelFlags_saturatedCenter",
+      "type": "boolean",
+      "doc": "Saturated pixel in the 3x3 region around the centroid."
+    },
+    {
+      "name": "pixelFlags_suspect",
+      "type": "boolean",
+      "doc": "DiaSource's footprint includes suspect pixels."
+    },
+    {
+      "name": "pixelFlags_suspectCenter",
+      "type": "boolean",
+      "doc": "Suspect pixel in the 3x3 region around the centroid."
+    },
+    {
+      "name": "pixelFlags_streak",
+      "type": "boolean",
+      "doc": "Streak in the DiaSource footprint."
+    },
+    {
+      "name": "pixelFlags_streakCenter",
+      "type": "boolean",
+      "doc": "Streak in the 3x3 region around the centroid."
+    },
+    {
+      "name": "pixelFlags_injected",
+      "type": "boolean",
+      "doc": "Injection in the DiaSource footprint."
+    },
+    {
+      "name": "pixelFlags_injectedCenter",
+      "type": "boolean",
+      "doc": "Injection in the 3x3 region around the centroid."
+    },
+    {
+      "name": "pixelFlags_injected_template",
+      "type": "boolean",
+      "doc": "Template injection in the DiaSource footprint."
+    },
+    {
+      "name": "pixelFlags_injected_templateCenter",
+      "type": "boolean",
+      "doc": "Template injection in the 3x3 region around the centroid."
+    },
+    {
+      "name": "glint_trail",
+      "type": "boolean",
+      "doc": "This flag is set if the source is part of a glint trail."
+    }
+  ]
+}

--- a/common/schema/11_1/lasair_statistics.py
+++ b/common/schema/11_1/lasair_statistics.py
@@ -1,0 +1,24 @@
+schema = {
+  "name": "lasair_statistics",
+  "version": "1.0",
+  "fields": [
+    {
+      "name": "nid",
+      "type": "int",
+      "doc": "Night number"
+    },
+    {
+      "name": "name",
+      "type": "bigstring",
+      "doc": "Which statistic"
+    },
+    {
+      "name": "value",
+      "type": "float",
+      "doc": "The statistic being stored"
+    }
+  ],
+  "indexes": [
+    "PRIMARY KEY (nid, name)"
+  ]
+}

--- a/common/schema/11_1/mma_area_hits.py
+++ b/common/schema/11_1/mma_area_hits.py
@@ -1,0 +1,41 @@
+schema = {
+  "name": "mma_area_hits",
+  "version": "1.0",
+  "fields": [
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "doc": "ZTF object identifier"
+    },
+    {
+      "name": "mw_id",
+      "type": "int",
+      "doc": "MMA area identifier"
+    },
+    {
+      "name": "contour",
+      "type": "float",
+      "doc": "2D skymap prob contour (0 to 1, smallest is best)"
+    },
+    {
+      "name": "distance",
+      "type": "float",
+      "doc": "Distance (Mpc) to host galaxy"
+    },
+    {
+      "name": "probdens2",
+      "type": "float",
+      "doc": "2D probability density, RA/Dec skymap"
+    },
+    {
+      "name": "probdens3",
+      "type": "float",
+      "doc": "3D probability density, RA/Dec/Distance skymap"
+    }
+  ],
+  "indexes": [
+    "PRIMARY KEY (`diaObjectId`)",
+    "KEY `mw_id_idx` (`mw_id`),"
+    "UNIQUE KEY `diaObjectId_mw_id_idx` (`diaObjectId`,`mw_id`)"
+  ]
+}

--- a/common/schema/11_1/mpc_orbits.py
+++ b/common/schema/11_1/mpc_orbits.py
@@ -1,0 +1,271 @@
+schema = {
+  'indexes':['PRIMARY KEY ("designation")'],
+  "name": "mpc_orbits",
+  "fields": [
+    {
+      "name": "id",
+      "type": "int",
+      "doc": "Internal ID (generally not seen/used by the user)"
+    },
+    {
+      "name": "designation",
+      "type": "string",
+      "doc": "The primary provisional designation in unpacked form (e.g. 2008 AB)."
+    },
+    {
+      "name": "packed_primary_provisional_designation",
+      "type": "string",
+      "doc": "The primary provisional designation in packed form (e.g. K08A00B)"
+    },
+    {
+      "name": "unpacked_primary_provisional_designation",
+      "type": "string",
+      "doc": "The primary provisional designation in unpacked form (e.g. 2008 AB)"
+    },
+    {
+      "name": "mpc_orb_jsonb",
+      "type": "string",
+      "doc": "Details of the orbit solution in JSON form"
+    },
+    {
+      "name": "created_at",
+      "type": "long",
+      "doc": "When this row was created"
+    },
+    {
+      "name": "updated_at",
+      "type": "long",
+      "doc": "When this row was updated"
+    },
+    {
+      "name": "orbit_type_int",
+      "type": "int",
+      "doc": "Orbit Type (Integer)"
+    },
+    {
+      "name": "u_param",
+      "type": "int",
+      "doc": "U parameter"
+    },
+    {
+      "name": "nopp",
+      "type": "int",
+      "doc": "number of oppositions"
+    },
+    {
+      "name": "arc_length_total",
+      "type": "double",
+      "doc": "Arc length over total observations [days]"
+    },
+    {
+      "name": "arc_length_sel",
+      "type": "double",
+      "doc": "Arc length over total observations *selected* [days]"
+    },
+    {
+      "name": "nobs_total",
+      "type": "int",
+      "doc": "Total number of all observations (optical + radar) available"
+    },
+    {
+      "name": "nobs_total_sel",
+      "type": "int",
+      "doc": "Total number of all observations (optical + radar) selected for use in orbit fitting"
+    },
+    {
+      "name": "a",
+      "type": "double",
+      "doc": "Semi Major Axis [au]"
+    },
+    {
+      "name": "q",
+      "type": "double",
+      "doc": "Pericenter Distance [au]"
+    },
+    {
+      "name": "e",
+      "type": "double",
+      "doc": "Eccentricity"
+    },
+    {
+      "name": "i",
+      "type": "double",
+      "doc": "Inclination [degrees]"
+    },
+    {
+      "name": "node",
+      "type": "double",
+      "doc": "Longitude of Ascending Node [degrees]"
+    },
+    {
+      "name": "argperi",
+      "type": "double",
+      "doc": "Argument of Pericenter [degrees]"
+    },
+    {
+      "name": "peri_time",
+      "type": "double",
+      "doc": "Time from Pericenter Passage [days]"
+    },
+    {
+      "name": "yarkovsky",
+      "type": "double",
+      "doc": "Yarkovsky Component [10^(-10)*au/day^2]"
+    },
+    {
+      "name": "srp",
+      "type": "double",
+      "doc": "Solar-Radiation Pressure Component [m^2/ton]"
+    },
+    {
+      "name": "a1",
+      "type": "double",
+      "doc": "A1 non-grav components [m^2/ton]"
+    },
+    {
+      "name": "a2",
+      "type": "double",
+      "doc": "A2 non-grav components [m^2/ton]"
+    },
+    {
+      "name": "a3",
+      "type": "double",
+      "doc": "A3 non-grav components [m^2/ton]"
+    },
+    {
+      "name": "dt",
+      "type": "double",
+      "doc": "DT non-grav component"
+    },
+    {
+      "name": "mean_anomaly",
+      "type": "double",
+      "doc": "Mean Anomaly [degrees]"
+    },
+    {
+      "name": "period",
+      "type": "double",
+      "doc": "Orbital Period [days]"
+    },
+    {
+      "name": "mean_motion",
+      "type": "double",
+      "doc": "Orbital Mean Motion [degrees per day]"
+    },
+    {
+      "name": "a_unc",
+      "type": "double",
+      "doc": "Uncertainty on Semi Major Axis [au]"
+    },
+    {
+      "name": "q_unc",
+      "type": "double",
+      "doc": "Uncertainty on Pericenter Distance [au]"
+    },
+    {
+      "name": "e_unc",
+      "type": "double",
+      "doc": "Uncertainty on Eccentricity"
+    },
+    {
+      "name": "i_unc",
+      "type": "double",
+      "doc": "Uncertainty on Inclination [degrees]"
+    },
+    {
+      "name": "node_unc",
+      "type": "double",
+      "doc": "Uncertainty on Longitude of Ascending Node [degrees]"
+    },
+    {
+      "name": "argperi_unc",
+      "type": "double",
+      "doc": "Uncertainty on Argument of Pericenter [degrees]"
+    },
+    {
+      "name": "peri_time_unc",
+      "type": "double",
+      "doc": "Uncertainty on Time from Pericenter Passage [days]"
+    },
+    {
+      "name": "yarkovsky_unc",
+      "type": "double",
+      "doc": "Uncertainty on Yarkovsky Component [10^(-10)*au/day^2]"
+    },
+    {
+      "name": "srp_unc",
+      "type": "double",
+      "doc": "Uncertainty on Solar-Radiation Pressure Component [m^2/ton]"
+    },
+    {
+      "name": "a1_unc",
+      "type": "double",
+      "doc": "Uncertainty on A1 non-grav components [m^2/ton]"
+    },
+    {
+      "name": "a2_unc",
+      "type": "double",
+      "doc": "Uncertainty on A2 non-grav components [m^2/ton]"
+    },
+    {
+      "name": "a3_unc",
+      "type": "double",
+      "doc": "Uncertainty on A3 non-grav components [m^2/ton]"
+    },
+    {
+      "name": "dt_unc",
+      "type": "double",
+      "doc": "Uncertainty on DT non-grav component"
+    },
+    {
+      "name": "mean_anomaly_unc",
+      "type": "double",
+      "doc": "Uncertainty on Mean Anomaly [degrees]"
+    },
+    {
+      "name": "period_unc",
+      "type": "double",
+      "doc": "Uncertainty on Orbital Period [days]"
+    },
+    {
+      "name": "mean_motion_unc",
+      "type": "double",
+      "doc": "Uncertainty on Orbital Mean Motion [degrees per day]"
+    },
+    {
+      "name": "epoch_mjd",
+      "type": "double",
+      "doc": "Epoch of the Orbfit-Solution in MJD"
+    },
+    {
+      "name": "h",
+      "type": "double",
+      "doc": "H-Magnitude"
+    },
+    {
+      "name": "g",
+      "type": "double",
+      "doc": "G-Slope Parameter"
+    },
+    {
+      "name": "not_normalized_rms",
+      "type": "double",
+      "doc": "unnormalized rms of the fit [arcsec]"
+    },
+    {
+      "name": "normalized_rms",
+      "type": "double",
+      "doc": "rms of the fit [unitless]"
+    },
+    {
+      "name": "earth_moid",
+      "type": "double",
+      "doc": "Minimum Orbit Intersection Distance [au] with respect to the Earths Orbit"
+    },
+    {
+      "name": "fitting_datetime",
+      "type": "long",
+      "doc": "Date of the last orbit fit"
+    }
+  ]
+}

--- a/common/schema/11_1/objects.py
+++ b/common/schema/11_1/objects.py
@@ -1,0 +1,769 @@
+schema = {
+  "name": "objects",
+  "fields": [
+    {
+      "section": "Basic information",
+      "doc": "ID, position, proper motion"
+    },
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "origin": "lsst",
+      "doc": "ID for this object",
+      "extra": "NOT NULL"
+    },
+    {
+      "name": "ra",
+      "type": "double",
+      "origin": "lsst",
+      "doc": "Mean RA of this object"
+    },
+    {
+      "name": "decl",
+      "type": "double",
+      "origin": "lsst",
+      "doc": "Mean Dec of this object"
+    },
+    {
+      "section": "Lightcurve interval",
+      "doc": "MJD of the first and last diaSource of this diaObject"
+    },
+    {
+      "name": "lastDiaSourceMjdTai",
+      "type": "double",
+      "origin": "lsst",
+      "doc": "Latest MJD of a diaSource"
+    },
+    {
+      "name": "firstDiaSourceMjdTai",
+      "type": "double",
+      "origin": "lsst",
+      "doc": "Earliest MJD of a diaSource"
+    },
+    {
+      "section": "Latest Flux",
+      "doc": "Most recent fluxes with errors"
+    },
+    {
+      "name": "latest_psfFlux",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Latest flux of any band (nJy)"
+    },
+    {
+      "name": "u_psfFlux",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Latest u flux (nJy)"
+    },
+    {
+      "name": "u_latestMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "MJD of Latest u flux"
+    },
+    {
+      "name": "u_psfFluxMean",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Weighted mean point-source model flux for u filter. (nJy)"
+    },
+    {
+      "name": "u_psfFluxMeanErr",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Standard error of u_psfFluxMean. (nJy)"
+    },
+    {
+      "name": "g_psfFlux",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Latest g flux (nJy)"
+    },
+    {
+      "name": "g_latestMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "MJD of Latest g flux"
+    },
+    {
+      "name": "g_psfFluxMean",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Weighted mean point-source model flux for g filter. (nJy)"
+    },
+    {
+      "name": "g_psfFluxMeanErr",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Standard error of g_psfFluxMean. (nJy)"
+    },
+    {
+      "name": "r_psfFlux",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Latest r flux (nJy)"
+    },
+    {
+      "name": "r_latestMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "MJD of Latest r flux"
+    },
+    {
+      "name": "r_psfFluxMean",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Weighted mean point-source model flux for r filter. (nJy)"
+    },
+    {
+      "name": "r_psfFluxMeanErr",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Standard error of r_psfFluxMean. (nJy)"
+    },
+    {
+      "name": "i_psfFlux",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Latest i flux (nJy)"
+    },
+    {
+      "name": "i_latestMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "MJD of Latest i flux"
+    },
+    {
+      "name": "i_psfFluxMean",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Weighted mean point-source model flux for i filter. (nJy)"
+    },
+    {
+      "name": "i_psfFluxMeanErr",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Standard error of i_psfFluxMean. (nJy)"
+    },
+    {
+      "name": "z_psfFlux",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Latest z flux (nJy)"
+    },
+    {
+      "name": "z_latestMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "MJD of Latest z flux"
+    },
+    {
+      "name": "z_psfFluxMean",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Weighted mean point-source model flux for z filter. (nJy)"
+    },
+    {
+      "name": "z_psfFluxMeanErr",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Standard error of z_psfFluxMean. (nJy)"
+    },
+    {
+      "name": "y_psfFlux",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Latest y flux (nJy)"
+    },
+    {
+      "name": "y_latestMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "MJD of Latest y flux"
+    },
+    {
+      "name": "y_psfFluxMean",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Weighted mean point-source model flux for y filter. (nJy)"
+    },
+    {
+      "name": "y_psfFluxMeanErr",
+      "type": "float",
+      "origin": "lsst",
+      "doc": "Standard error of y_psfFluxMean. (nJy)"
+    },
+    {
+      "section": "Counting and Reliability",
+      "doc": "Counts of diaSources, median of R"
+    },
+    {
+      "name": "medianR",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Median of reliability for the diaSources in this diaObject"
+    },
+    {
+      "name": "latestR",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Most recent reliability for the diaSources in this diaObject"
+    },
+    {
+      "name": "nDiaSources",
+      "type": "int",
+      "origin": "lsst",
+      "doc": "Number of diaSources associated with this diaObject"
+    },
+    {
+      "name": "nPosDiaSources",
+      "type": "int",
+      "origin": "lasair",
+      "doc": "Number of diaSources with positive flux associated with this diaObject"
+    },
+    {
+      "name": "nPosDiaSourcesNights",
+      "type": "int",
+      "origin": "lasair",
+      "doc": "Number of nights on which this object was detected with positive flux"
+    },
+    {
+      "name": "nSourcesGood",
+      "type": "int",
+      "origin": "lasair",
+      "doc": "Number sources with reliability > 0.5"
+    },
+    {
+      "name": "nuSources",
+      "type": "int",
+      "origin": "lasair",
+      "doc": "Number of u sources"
+    },
+    {
+      "name": "ngSources",
+      "type": "int",
+      "origin": "lasair",
+      "doc": "Number of g sources"
+    },
+    {
+      "name": "nrSources",
+      "type": "int",
+      "origin": "lasair",
+      "doc": "Number of r sources"
+    },
+    {
+      "name": "niSources",
+      "type": "int",
+      "origin": "lasair",
+      "doc": "Number of i sources"
+    },
+    {
+      "name": "nzSources",
+      "type": "int",
+      "origin": "lasair",
+      "doc": "Number of z sources"
+    },
+    {
+      "name": "nySources",
+      "type": "int",
+      "origin": "lasair",
+      "doc": "Number of y sources"
+    },
+    {
+      "section": "Other/Nearest objects",
+      "doc": "Other/Nearest objects from LSST and other catalogs"
+    },
+    {
+      "name": "tns_name",
+      "type": "string",
+      "origin": "external",
+      "doc": "TNS name of this object if it exists"
+    },
+    {
+      "section": "Absolute magnitude",
+      "doc": "Brightness at 1 parsec"
+    },
+    {
+      "name": "absMag",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Peak absolute magnitude (extinction corrected) if host galaxy with distance available"
+    },
+    {
+      "name": "absMagMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Peak absolute magnitude time if host galaxy with distance available"
+    },
+    {
+      "section": "BazinBlackBody (BBB)",
+      "doc": "Lightcurve fit as Bazin or Exp in time, Blackbody in wavelength"
+    },
+    {
+      "name": "BBBRiseRate",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Fitted Bazin or Exp rise rate"
+    },
+    {
+      "name": "BBBFallRate",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Fitted Bazin fall rate or NULL if Exp"
+    },
+    {
+      "name": "BBBTemp",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Fitted Bazin temperature, (kiloKelvins)"
+    },
+    {
+      "name": "BBBPeakFlux",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "If Bazin fit, the peak flux (nJy), else NULL"
+    },
+    {
+      "name": "BBBPeakMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "If Bazin fit, the time of the peak brightness, else NULL"
+    },
+    {
+      "name": "BBBPeakAbsMag",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "If Bazin fit and Sherlock host with distance, the peak absolute magnitude, else NULL"
+    },
+    {
+      "section": "Milky Way",
+      "doc": "Galactic latitude and extinction"
+    },
+    {
+      "name": "glat",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Galactic latitude"
+    },
+    {
+      "name": "ebv",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Extinction E(B-V) Schlegel, Finkbeiner & Davis (1998)"
+    },
+    {
+      "section": "Jump detector",
+      "doc": "Number of sigma jump from 20 day mean"
+    },
+    {
+      "name": "jump1",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Largest sigma jump of recent flux from previous -70 to -10  days"
+    },
+    {
+      "name": "jump2",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Largest sigma jump of recent flux in different band from previous -70 to -10  days"
+    },
+    {
+      "section": "Pair colours",
+      "doc": "Colours from 33-minute paired diaSources"
+    },
+    {
+      "name": "latestPairMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Latest pair MJD"
+    },
+    {
+      "name": "latestPairColourMag",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Magnitude difference from latest pair"
+    },
+    {
+      "name": "latestPairColourBands",
+      "type": "string",
+      "origin": "lasair",
+      "doc": "Bands used for latest pair colour, eg g-r, u-r"
+    },
+    {
+      "name": "latestPairColourTemp",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Extinction corrected blackbody fit temperature from latest pair, kiloKelvin"
+    },
+    {
+      "name": "penultimatePairMJD",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Penultimate pair MJD"
+    },
+    {
+      "name": "penultimatePairColourMag",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Magnitude difference from Penultimate pair"
+    },
+    {
+      "name": "penultimatePairColourBands",
+      "type": "string",
+      "origin": "lasair",
+      "doc": "Bands used for penultimate pair colour, eg g-r, u-r"
+    },
+    {
+      "name": "penultimatePairColourTemp",
+      "type": "float",
+      "origin": "lasair",
+      "doc": "Extinction corrected blackbody fit temperature from penultimate pair, kiloKelvin"
+    },
+    {
+      "section": "Utility",
+      "doc": "Other attributes"
+    },
+    {
+      "name": "htm16",
+      "type": "long",
+      "origin": "lasair",
+      "doc": "Hierarchical Triangular Mesh level 16",
+      "extra": "NOT NULL"
+    },
+    {
+      "name": "timestamp",
+      "type": "timestamp",
+      "extra": "DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+      "origin": "external",
+      "doc": "Time at which this object last modified"
+    }
+  ],
+  "ext_fields": [
+    {
+      "name": "validityStartMjdTai",
+      "type": "double",
+      "doc": "Processing time when validity of this diaObject starts, expressed as Modified Julian Date, International Atomic Time."
+    },
+    {
+      "name": "raErr",
+      "type": "float",
+      "doc": "Angular error of Right Ascension (\u2202RA*cos(Dec)) [deg]."
+    },
+    {
+      "name": "decErr",
+      "type": "float",
+      "doc": "Angular error of dec [deg]."
+    },
+    {
+      "name": "ra_dec_Cov",
+      "type": "float",
+      "doc": "Covariance between Right Ascension (RA*cos(Dec)) and dec [deg**2]."
+    },
+    {
+      "name": "u_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of u_psfFlux [nJy]."
+    },
+    {
+      "name": "u_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of u-band data points."
+    },
+    {
+      "name": "u_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for u filter [nJy]."
+    },
+    {
+      "name": "u_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of u_fpFluxMean [nJy]."
+    },
+    {
+      "name": "g_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of g_psfFlux [nJy]."
+    },
+    {
+      "name": "g_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of g-band data points."
+    },
+    {
+      "name": "g_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for g filter [nJy]."
+    },
+    {
+      "name": "g_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of g_fpFluxMean [nJy]."
+    },
+    {
+      "name": "r_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of r_psfFlux [nJy]."
+    },
+    {
+      "name": "r_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of r-band data points."
+    },
+    {
+      "name": "r_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for r filter [nJy]."
+    },
+    {
+      "name": "r_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of r_fpFluxMean [nJy]."
+    },
+    {
+      "name": "i_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of i_psfFlux [nJy]."
+    },
+    {
+      "name": "i_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of i-band data points."
+    },
+    {
+      "name": "i_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for i filter [nJy]."
+    },
+    {
+      "name": "i_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of i_fpFluxMean [nJy]."
+    },
+    {
+      "name": "z_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of z_psfFlux [nJy]."
+    },
+    {
+      "name": "z_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of z-band data points."
+    },
+    {
+      "name": "z_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for z filter [nJy]."
+    },
+    {
+      "name": "z_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of z_fpFluxMean [nJy]."
+    },
+    {
+      "name": "y_psfFluxSigma",
+      "type": "float",
+      "doc": "Standard deviation of the distribution of y_psfFlux [nJy]."
+    },
+    {
+      "name": "y_psfFluxNdata",
+      "type": "int",
+      "doc": "The number of y-band data points."
+    },
+    {
+      "name": "y_fpFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for y filter [nJy]."
+    },
+    {
+      "name": "y_fpFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of y_fpFluxMean [nJy]."
+    },
+    {
+      "name": "u_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for u filter [nJy]."
+    },
+    {
+      "name": "u_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of u_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "g_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for g filter [nJy]."
+    },
+    {
+      "name": "g_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of g_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "r_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for r filter [nJy]."
+    },
+    {
+      "name": "r_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of r_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "i_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for i filter [nJy]."
+    },
+    {
+      "name": "i_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of i_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "z_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for z filter [nJy]."
+    },
+    {
+      "name": "z_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of z_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "y_scienceFluxMean",
+      "type": "float",
+      "doc": "Weighted mean forced photometry flux for y filter [nJy]."
+    },
+    {
+      "name": "y_scienceFluxMeanErr",
+      "type": "float",
+      "doc": "Standard error of y_scienceFluxMean [nJy]."
+    },
+    {
+      "name": "u_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed u band fluxes [nJy]."
+    },
+    {
+      "name": "u_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed u band fluxes [nJy]."
+    },
+    {
+      "name": "u_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between u band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "u_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the u band flux errors [nJy]."
+    },
+    {
+      "name": "g_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed g band fluxes [nJy]."
+    },
+    {
+      "name": "g_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed g band fluxes [nJy]."
+    },
+    {
+      "name": "g_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between g band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "g_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the g band flux errors [nJy]."
+    },
+    {
+      "name": "r_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed r band fluxes [nJy]."
+    },
+    {
+      "name": "r_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed r band fluxes [nJy]."
+    },
+    {
+      "name": "r_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between r band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "r_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the r band flux errors [nJy]."
+    },
+    {
+      "name": "i_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed i band fluxes [nJy]."
+    },
+    {
+      "name": "i_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed i band fluxes [nJy]."
+    },
+    {
+      "name": "i_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between i band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "i_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the i band flux errors [nJy]."
+    },
+    {
+      "name": "z_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed z band fluxes [nJy]."
+    },
+    {
+      "name": "z_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed z band fluxes [nJy]."
+    },
+    {
+      "name": "z_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between z band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "z_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the z band flux errors [nJy]."
+    },
+    {
+      "name": "y_psfFluxMin",
+      "type": "float",
+      "doc": "Minimum observed y band fluxes [nJy]."
+    },
+    {
+      "name": "y_psfFluxMax",
+      "type": "float",
+      "doc": "Maximum observed y band fluxes [nJy]."
+    },
+    {
+      "name": "y_psfFluxMaxSlope",
+      "type": "float",
+      "doc": "Maximum slope between y band flux obsevations max(delta_flux/delta_time) [nJy/d]."
+    },
+    {
+      "name": "y_psfFluxErrMean",
+      "type": "float",
+      "doc": "Mean of the y band flux errors [nJy]."
+    }
+  ],
+  "indexes": [
+    "PRIMARY KEY (diaObjectId)",
+    "KEY htmid16idx (htm16)",
+    "KEY idxMaxTai (lastDiaSourceMjdTai)"
+  ]
+}

--- a/common/schema/11_1/sherlock_classifications.py
+++ b/common/schema/11_1/sherlock_classifications.py
@@ -1,0 +1,154 @@
+schema = {
+  "name": "sherlock_classifications",
+  "version": "1.0",
+  "fields": [
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "doc": "ZTF object identifier, also known as transient_object_id"
+    },
+    {
+      "name": "classification",
+      "type": "string",
+      "doc": "Top-ranked contextual classification for the transient (NULL, AGN, BS, CV, NT, ORPHAN, SN, UNCLEAR, VS)"
+    },
+    {
+      "name": "association_type",
+      "type": "string",
+      "doc": "Association classification for the transient (NULL, AGN, BS, CV, NT, ORPHAN, SN, UNCLEAR, VS)"
+    },
+    {
+      "name": "catalogue_table_name",
+      "type": "bigstring",
+      "doc": "Name/s of catalogue/s from which the best crossmatch is made"
+    },
+    {
+      "name": "catalogue_object_id",
+      "type": "bigstring",
+      "doc": "Identifier in the catalogue/s from which the best crossmatch is made"
+    },
+    {
+      "name": "catalogue_object_type",
+      "type": "string",
+      "doc": "Type of catalogue from which the best crossmatch is made"
+    },
+    {
+      "name": "raDeg",
+      "type": "double",
+      "doc": "RA in degrees of the transient"
+    },
+    {
+      "name": "decDeg",
+      "type": "double",
+      "doc": "Dec in degrees of the transient"
+    },
+    {
+      "name": "separationArcsec",
+      "type": "float",
+      "doc": "Transient's angular separation (arcseconds) from the top-ranked catalogue source match"
+    },
+    {
+      "name": "northSeparationArcsec",
+      "type": "float",
+      "doc": "Transient's angular separation (arcseconds) from the top-ranked catalogue source match"
+    },
+    {
+      "name": "eastSeparationArcsec",
+      "type": "float",
+      "doc": "Transient's angular separation (arcseconds) from the top-ranked catalogue source match"
+    },
+    {
+      "name": "physical_separation_kpc",
+      "type": "float",
+      "doc": "Distance in kilo parsec between transient and top-ranked catalogue source match"
+    },
+    {
+      "name": "direct_distance",
+      "type": "float",
+      "doc": "Determined from a non-redshift related measurement - e.g. Cepheids/standard candle (Mpc)"
+    },
+    {
+      "name": "distance",
+      "type": "float",
+      "doc": "Deprecated -- please use 'best_distance' instead",
+    },
+    {
+     "name": "best_distance",
+     "type": "float",
+     "doc": "Luminosity distance calculated from the most accurate distance measurement (Mpc)"
+    },
+    {
+     "name": "best_distance_flag",
+     "type": "string",
+     "doc": "Type of distance measurement used to calculate 'best_distance'.  Direct distance (dd), Spectroscopic Redshift (sz) or Photometric Redshift (pz)"
+    },
+    {
+     "name": "best_distance_source",
+     "type": "bigstring",
+     "doc": "Source catalogue for 'best_distance'"
+    },
+    {
+      "name": "z",
+      "type": "float",
+      "doc": "Redshift of the top-ranked catalogue source match"
+    },
+    {
+      "name": "photoZ",
+      "type": "float",
+      "doc": "Redshift of the top-ranked catalogue source match"
+    },
+    {
+      "name": "photoZErr",
+      "type": "float",
+      "doc": "Redshift of the top-ranked catalogue source match"
+    },
+    {
+      "name": "Mag",
+      "type": "float",
+      "doc": "Magnitude"
+    },
+    {
+      "name": "MagFilter",
+      "type": "string",
+      "doc": "Magnitude filter"
+    },
+    {
+      "name": "MagErr",
+      "type": "float",
+      "doc": "Magnitude error"
+    },
+    {
+      "name": "classificationReliability",
+      "type": "int",
+      "doc": "Reliability of classification"
+    },
+    {
+      "name": "major_axis_arcsec",
+      "type": "float",
+      "doc": "Size of associated galaxy in arcsec"
+    },
+    {
+      "name": "annotator",
+      "type": "bigstring",
+      "doc": "Information about this annotation"
+    },
+    {
+      "name": "additional_output",
+      "type": "bigstring",
+      "doc": "Addititonal information about this annotation"
+    },
+    {
+      "name": "description",
+      "type": "text",
+      "doc": "Long-form, human-readable summary of the transient's characteristics as infered from Sherlock's classification"
+    },
+    {
+      "name": "summary",
+      "type": "bigstring",
+      "doc": "Short-form summary of the transient's context usual for webpage quick-look summaries"
+    }
+  ],
+  "indexes": [
+    "PRIMARY KEY (`diaObjectId`)"
+  ]
+}

--- a/common/schema/11_1/ssObjects.py
+++ b/common/schema/11_1/ssObjects.py
@@ -1,0 +1,406 @@
+schema = {
+  'indexes':['PRIMARY KEY ("ssObjectId")'],
+  "name": "ssObjects",
+  "fields": [
+    {
+      "name": "ssObjectId",
+      "type": "long",
+      "doc": "Unique identifier."
+    },
+    {
+      "name": "designation",
+      "type": "string",
+      "doc": "The unpacked primary provisional designation for this object."
+    },
+    {
+      "name": "nObs",
+      "type": "int",
+      "doc": "Total number of LSST observations of this object."
+    },
+    {
+      "name": "arc",
+      "type": "float",
+      "doc": "Timespan (\"arc\") of all LSST observations, t_{last} - t_{first}"
+    },
+    {
+      "name": "firstObservationMjdTai",
+      "type": "double",
+      "doc": "The time of the first LSST observation of this object (could be precovered), TAI."
+    },
+    {
+      "name": "MOIDEarth",
+      "type": "float",
+      "doc": "Minimum orbit intersection distance to Earth."
+    },
+    {
+      "name": "MOIDEarthDeltaV",
+      "type": "float",
+      "doc": "DeltaV at the MOID point."
+    },
+    {
+      "name": "MOIDEarthEclipticLongitude",
+      "type": "float",
+      "doc": "Ecliptic longitude of the MOID point (Earth's orbit)."
+    },
+    {
+      "name": "MOIDEarthTrueAnomaly",
+      "type": "float",
+      "doc": "True anomaly of the MOID point on Earth's orbit."
+    },
+    {
+      "name": "MOIDEarthTrueAnomalyObject",
+      "type": "float",
+      "doc": "True anomaly of the MOID point on the object's orbit."
+    },
+    {
+      "name": "tisserand_J",
+      "type": "float",
+      "doc": "Tisserand parameter with respect to Jupiter (T_J)."
+    },
+    {
+      "name": "extendednessMax",
+      "type": "float",
+      "doc": "Maximum `extendedness` value from the DiaSource."
+    },
+    {
+      "name": "extendednessMedian",
+      "type": "float",
+      "doc": "Median `extendedness` value from the DiaSource."
+    },
+    {
+      "name": "extendednessMin",
+      "type": "float",
+      "doc": "Minimum `extendedness` value from the DiaSource."
+    },
+    {
+      "name": "u_nObs",
+      "type": "int",
+      "doc": "Total number of data points (u band)."
+    },
+    {
+      "name": "u_H",
+      "type": "float",
+      "doc": "Best fit absolute magnitude (u band)."
+    },
+    {
+      "name": "u_HErr",
+      "type": "float",
+      "doc": "Error in the estimate of H (u band)."
+    },
+    {
+      "name": "u_G12",
+      "type": "float",
+      "doc": "Best fit G12 slope parameter (u band)."
+    },
+    {
+      "name": "u_G12Err",
+      "type": "float",
+      "doc": "Error in the estimate of G12 (u band)."
+    },
+    {
+      "name": "u_H_u_G12_Cov",
+      "type": "float",
+      "doc": "H\u2013G12 covariance (u band)."
+    },
+    {
+      "name": "u_nObsUsed",
+      "type": "int",
+      "doc": "The number of data points used to fit the phase curve (u band)."
+    },
+    {
+      "name": "u_Chi2",
+      "type": "float",
+      "doc": "Chi^2 statistic of the phase curve fit (u band)."
+    },
+    {
+      "name": "u_phaseAngleMin",
+      "type": "float",
+      "doc": "Minimum phase angle observed (u band)."
+    },
+    {
+      "name": "u_phaseAngleMax",
+      "type": "float",
+      "doc": "Maximum phase angle observed (u band)."
+    },
+    {
+      "name": "u_slope_fit_failed",
+      "type": "boolean",
+      "doc": "G12 fit failed in u band. G12 contains a fiducial value used to fit H."
+    },
+    {
+      "name": "g_nObs",
+      "type": "int",
+      "doc": "Total number of data points (g band)."
+    },
+    {
+      "name": "g_H",
+      "type": "float",
+      "doc": "Best fit absolute magnitude (g band)."
+    },
+    {
+      "name": "g_HErr",
+      "type": "float",
+      "doc": "Error in the estimate of H (g band)."
+    },
+    {
+      "name": "g_G12",
+      "type": "float",
+      "doc": "Best fit G12 slope parameter (g band)."
+    },
+    {
+      "name": "g_G12Err",
+      "type": "float",
+      "doc": "Error in the estimate of G12 (g band)."
+    },
+    {
+      "name": "g_H_g_G12_Cov",
+      "type": "float",
+      "doc": "H\u2013G12 covariance (g band)."
+    },
+    {
+      "name": "g_nObsUsed",
+      "type": "int",
+      "doc": "The number of data points used to fit the phase curve (g band)."
+    },
+    {
+      "name": "g_Chi2",
+      "type": "float",
+      "doc": "Chi^2 statistic of the phase curve fit (g band)."
+    },
+    {
+      "name": "g_phaseAngleMin",
+      "type": "float",
+      "doc": "Minimum phase angle observed (g band)."
+    },
+    {
+      "name": "g_phaseAngleMax",
+      "type": "float",
+      "doc": "Maximum phase angle observed (g band)."
+    },
+    {
+      "name": "g_slope_fit_failed",
+      "type": "boolean",
+      "doc": "G12 fit failed in g band. G12 contains a fiducial value used to fit H."
+    },
+    {
+      "name": "r_nObs",
+      "type": "int",
+      "doc": "Total number of data points (r band)."
+    },
+    {
+      "name": "r_H",
+      "type": "float",
+      "doc": "Best fit absolute magnitude (r band)."
+    },
+    {
+      "name": "r_HErr",
+      "type": "float",
+      "doc": "Error in the estimate of H (r band)."
+    },
+    {
+      "name": "r_G12",
+      "type": "float",
+      "doc": "Best fit G12 slope parameter (r band)."
+    },
+    {
+      "name": "r_G12Err",
+      "type": "float",
+      "doc": "Error in the estimate of G12 (r band)."
+    },
+    {
+      "name": "r_H_r_G12_Cov",
+      "type": "float",
+      "doc": "H\u2013G12 covariance (r band)."
+    },
+    {
+      "name": "r_nObsUsed",
+      "type": "int",
+      "doc": "The number of data points used to fit the phase curve (r band)."
+    },
+    {
+      "name": "r_Chi2",
+      "type": "float",
+      "doc": "Chi^2 statistic of the phase curve fit (r band)."
+    },
+    {
+      "name": "r_phaseAngleMin",
+      "type": "float",
+      "doc": "Minimum phase angle observed (r band)."
+    },
+    {
+      "name": "r_phaseAngleMax",
+      "type": "float",
+      "doc": "Maximum phase angle observed (r band)."
+    },
+    {
+      "name": "r_slope_fit_failed",
+      "type": "boolean",
+      "doc": "G12 fit failed in r band. G12 contains a fiducial value used to fit H."
+    },
+    {
+      "name": "i_nObs",
+      "type": "int",
+      "doc": "Total number of data points (i band)."
+    },
+    {
+      "name": "i_H",
+      "type": "float",
+      "doc": "Best fit absolute magnitude (i band)."
+    },
+    {
+      "name": "i_HErr",
+      "type": "float",
+      "doc": "Error in the estimate of H (i band)."
+    },
+    {
+      "name": "i_G12",
+      "type": "float",
+      "doc": "Best fit G12 slope parameter (i band)."
+    },
+    {
+      "name": "i_G12Err",
+      "type": "float",
+      "doc": "Error in the estimate of G12 (i band)."
+    },
+    {
+      "name": "i_H_i_G12_Cov",
+      "type": "float",
+      "doc": "H\u2013G12 covariance (i band)."
+    },
+    {
+      "name": "i_nObsUsed",
+      "type": "int",
+      "doc": "The number of data points used to fit the phase curve (i band)."
+    },
+    {
+      "name": "i_Chi2",
+      "type": "float",
+      "doc": "Chi^2 statistic of the phase curve fit (i band)."
+    },
+    {
+      "name": "i_phaseAngleMin",
+      "type": "float",
+      "doc": "Minimum phase angle observed (i band)."
+    },
+    {
+      "name": "i_phaseAngleMax",
+      "type": "float",
+      "doc": "Maximum phase angle observed (i band)."
+    },
+    {
+      "name": "i_slope_fit_failed",
+      "type": "boolean",
+      "doc": "G12 fit failed in i band. G12 contains a fiducial value used to fit H."
+    },
+    {
+      "name": "z_nObs",
+      "type": "int",
+      "doc": "Total number of data points (z band)."
+    },
+    {
+      "name": "z_H",
+      "type": "float",
+      "doc": "Best fit absolute magnitude (z band)."
+    },
+    {
+      "name": "z_HErr",
+      "type": "float",
+      "doc": "Error in the estimate of H (z band)."
+    },
+    {
+      "name": "z_G12",
+      "type": "float",
+      "doc": "Best fit G12 slope parameter (z band)."
+    },
+    {
+      "name": "z_G12Err",
+      "type": "float",
+      "doc": "Error in the estimate of G12 (z band)."
+    },
+    {
+      "name": "z_H_z_G12_Cov",
+      "type": "float",
+      "doc": "H\u2013G12 covariance (z band)."
+    },
+    {
+      "name": "z_nObsUsed",
+      "type": "int",
+      "doc": "The number of data points used to fit the phase curve (z band)."
+    },
+    {
+      "name": "z_Chi2",
+      "type": "float",
+      "doc": "Chi^2 statistic of the phase curve fit (z band)."
+    },
+    {
+      "name": "z_phaseAngleMin",
+      "type": "float",
+      "doc": "Minimum phase angle observed (z band)."
+    },
+    {
+      "name": "z_phaseAngleMax",
+      "type": "float",
+      "doc": "Maximum phase angle observed (z band)."
+    },
+    {
+      "name": "z_slope_fit_failed",
+      "type": "boolean",
+      "doc": "G12 fit failed in z band. G12 contains a fiducial value used to fit H."
+    },
+    {
+      "name": "y_nObs",
+      "type": "int",
+      "doc": "Total number of data points (y band)."
+    },
+    {
+      "name": "y_H",
+      "type": "float",
+      "doc": "Best fit absolute magnitude (y band)."
+    },
+    {
+      "name": "y_HErr",
+      "type": "float",
+      "doc": "Error in the estimate of H (y band)."
+    },
+    {
+      "name": "y_G12",
+      "type": "float",
+      "doc": "Best fit G12 slope parameter (y band)."
+    },
+    {
+      "name": "y_G12Err",
+      "type": "float",
+      "doc": "Error in the estimate of G12 (y band)."
+    },
+    {
+      "name": "y_H_y_G12_Cov",
+      "type": "float",
+      "doc": "H\u2013G12 covariance (y band)."
+    },
+    {
+      "name": "y_nObsUsed",
+      "type": "int",
+      "doc": "The number of data points used to fit the phase curve (y band)."
+    },
+    {
+      "name": "y_Chi2",
+      "type": "float",
+      "doc": "Chi^2 statistic of the phase curve fit (y band)."
+    },
+    {
+      "name": "y_phaseAngleMin",
+      "type": "float",
+      "doc": "Minimum phase angle observed (y band)."
+    },
+    {
+      "name": "y_phaseAngleMax",
+      "type": "float",
+      "doc": "Maximum phase angle observed (y band)."
+    },
+    {
+      "name": "y_slope_fit_failed",
+      "type": "boolean",
+      "doc": "G12 fit failed in y band. G12 contains a fiducial value used to fit H."
+    }
+  ]
+}

--- a/common/schema/11_1/ssSources.py
+++ b/common/schema/11_1/ssSources.py
@@ -1,0 +1,201 @@
+schema = {
+  'indexes':['PRIMARY KEY ("ssObjectId", "diaSourceId")'],
+  "name": "ssSources",
+  "fields": [
+    {
+      "name": "diaSourceId",
+      "type": "long",
+      "doc": "Unique identifier of the observation (matching DiaSource.diaSourceId)."
+    },
+    {
+      "name": "ssObjectId",
+      "type": "long",
+      "doc": "Unique LSST identifier of the Solar System object."
+    },
+    {
+      "name": "designation",
+      "type": "string",
+      "doc": "The unpacked primary provisional designation for this object."
+    },
+    {
+      "name": "eclLambda",
+      "type": "double",
+      "doc": "Ecliptic longitude, converted from the observed coordinates."
+    },
+    {
+      "name": "eclBeta",
+      "type": "double",
+      "doc": "Ecliptic latitude, converted from the observed coordinates."
+    },
+    {
+      "name": "galLon",
+      "type": "double",
+      "doc": "Galactic longitude, converted from the observed coordinates."
+    },
+    {
+      "name": "galLat",
+      "type": "double",
+      "doc": "Galactic latitude, converted from the observed coordinates."
+    },
+    {
+      "name": "elongation",
+      "type": "float",
+      "doc": "Solar elongation of the object at the time of observation."
+    },
+    {
+      "name": "phaseAngle",
+      "type": "float",
+      "doc": "Phase angle between the Sun, object, and observer."
+    },
+    {
+      "name": "topoRange",
+      "type": "float",
+      "doc": "Topocentric distance (delta) at light-emission time."
+    },
+    {
+      "name": "topoRangeRate",
+      "type": "float",
+      "doc": "Topocentric radial (line-of-sight) velocity (deldot); positive values indicate motion away from the observer."
+    },
+    {
+      "name": "helioRange",
+      "type": "float",
+      "doc": "Heliocentric distance (r) at light-emission time."
+    },
+    {
+      "name": "helioRangeRate",
+      "type": "float",
+      "doc": "Heliocentric radial velocity (rdot); positive values indicate motion away from the Sun."
+    },
+    {
+      "name": "ephRa",
+      "type": "double",
+      "doc": "Predicted ICRS right ascension from the orbit in mpc_orbits."
+    },
+    {
+      "name": "ephDec",
+      "type": "double",
+      "doc": "Predicted ICRS declination from the orbit in mpc_orbits."
+    },
+    {
+      "name": "ephVmag",
+      "type": "float",
+      "doc": "Predicted magnitude in V band, computed from mpc_orbits data including the mpc_orbits-provided (H, G) estimates"
+    },
+    {
+      "name": "ephRate",
+      "type": "float",
+      "doc": "Total predicted on-sky angular rate of motion."
+    },
+    {
+      "name": "ephRateRa",
+      "type": "float",
+      "doc": "Predicted on-sky angular rate in the R.A. direction (includes the cos(dec) factor)."
+    },
+    {
+      "name": "ephRateDec",
+      "type": "float",
+      "doc": "Predicted on-sky angular rate in the declination direction."
+    },
+    {
+      "name": "ephOffset",
+      "type": "float",
+      "doc": "Total observed versus predicted angular separation on the sky."
+    },
+    {
+      "name": "ephOffsetRa",
+      "type": "double",
+      "doc": "Offset between observed and predicted position in the R.A. direction (includes cos(dec) term)."
+    },
+    {
+      "name": "ephOffsetDec",
+      "type": "double",
+      "doc": "Offset between observed and predicted position in declination."
+    },
+    {
+      "name": "ephOffsetAlongTrack",
+      "type": "float",
+      "doc": "Offset between observed and predicted position in the along-track direction on the sky."
+    },
+    {
+      "name": "ephOffsetCrossTrack",
+      "type": "float",
+      "doc": "Offset between observed and predicted position in the cross-track direction on the sky."
+    },
+    {
+      "name": "helio_x",
+      "type": "float",
+      "doc": "Cartesian heliocentric X coordinate at light-emission time (ICRS)."
+    },
+    {
+      "name": "helio_y",
+      "type": "float",
+      "doc": "Cartesian heliocentric Y coordinate at light-emission time (ICRS)."
+    },
+    {
+      "name": "helio_z",
+      "type": "float",
+      "doc": "Cartesian heliocentric Z coordinate at light-emission time (ICRS)."
+    },
+    {
+      "name": "helio_vx",
+      "type": "float",
+      "doc": "Cartesian heliocentric X velocity at light-emission time (ICRS)."
+    },
+    {
+      "name": "helio_vy",
+      "type": "float",
+      "doc": "Cartesian heliocentric Y velocity at light-emission time (ICRS)."
+    },
+    {
+      "name": "helio_vz",
+      "type": "float",
+      "doc": "Cartesian heliocentric Z velocity at light-emission time (ICRS)."
+    },
+    {
+      "name": "helio_vtot",
+      "type": "float",
+      "doc": "The magnitude of the heliocentric velocity vector, sqrt(vx*vx + vy*vy + vz*vz)."
+    },
+    {
+      "name": "topo_x",
+      "type": "float",
+      "doc": "Cartesian topocentric X coordinate at light-emission time (ICRS)."
+    },
+    {
+      "name": "topo_y",
+      "type": "float",
+      "doc": "Cartesian topocentric Y coordinate at light-emission time (ICRS)."
+    },
+    {
+      "name": "topo_z",
+      "type": "float",
+      "doc": "Cartesian topocentric Z coordinate at light-emission time (ICRS)."
+    },
+    {
+      "name": "topo_vx",
+      "type": "float",
+      "doc": "Cartesian topocentric X velocity at light-emission time (ICRS)."
+    },
+    {
+      "name": "topo_vy",
+      "type": "float",
+      "doc": "Cartesian topocentric Y velocity at light-emission time (ICRS)."
+    },
+    {
+      "name": "topo_vz",
+      "type": "float",
+      "doc": "Cartesian topocentric Z velocity at light-emission time (ICRS)."
+    },
+    {
+      "name": "topo_vtot",
+      "type": "float",
+      "doc": "The magnitude of the topocentric velocity vector, sqrt(vx*vx + vy*vy + vz*vz)."
+    },
+    {
+      "name": "diaDistanceRank",
+      "type": "int",
+      "doc": "The rank of the diaSourceId-identified source in terms of its closeness to the predicted SSO position.  If diaSourceId is the nearest DiaSource to this SSO prediction, diaSourceDistanceRank=1 would be set. If it is the second nearest, it would be 2, etc."
+    }
+  ]
+}

--- a/common/schema/11_1/watchlist_hits.py
+++ b/common/schema/11_1/watchlist_hits.py
@@ -1,0 +1,34 @@
+schema = {
+  "name": "watchlist_hits",
+  "version": "1.0",
+  "fields": [
+    {
+      "name": "diaObjectId",
+      "type": "long",
+      "doc": "ZTF object identifier"
+    },
+    {
+      "name": "wl_id",
+      "type": "int",
+      "doc": "Watchlist identifier in watchlists"
+    },
+    {
+      "name": "cone_id",
+      "type": "long",
+      "doc": "Cone identifier in watchlist_cones"
+    },
+    {
+      "name": "arcsec",
+      "type": "float",
+      "doc": "Distance between ZTF and watchlist source (arcsec)"
+    },
+    {
+      "name": "name",
+      "type": "bigstring",
+      "doc": "Name of cone given by user"
+    }
+  ],
+  "indexes": [
+    "PRIMARY KEY (`diaObjectId`, `cone_id`)"
+  ]
+}

--- a/common/schema/README.md
+++ b/common/schema/README.md
@@ -71,3 +71,54 @@ Check other tables in the same way.
 (3) The value of SCHEMA_VERSION should be up to date in `/common/settings.py` for both ingest nodes, 
 both filters, and web. In fact, it would be great to simply replace all the local copies of 
 `settings.py` from the template in the bootstrap node. 
+
+## Update June 2026
+How to do a minor schema update, where nothing is added to the objects table of MySQL
+```
+ssh lasair-lsst-dev
+
+cd lasair-lsst/deploy
+./stop.sh ingest
+
+cd ../common/schema
+git switch schema_11_1
+mkdir 11_1
+cp 11_0/*.py 11_1
+python3 1_fetch_avsc.py  11_1
+python3 2_join_object_schema.py 11_1
+python3 3_make_all_alter_table.py 11_0 11_1
+    MySQL databases
+    Cassandra
+    ALTER TABLE diaSources ADD "exposureTime"  float;
+    ALTER TABLE diaSources ADD "trailAlgorithm"  int;
+    ALTER TABLE diaSources ADD "trail_flag"  boolean;
+    ALTER TABLE diaSources ADD "reliabilityVersion"  ascii;
+git add 11_1
+git commit -m 'updated to 11_1'
+git push
+
+--> edit ../settings.py
+SCHEMA_VERSION = "11_1"
+and copy this to the nodes
+---------------
+ssh lasair-lsst-dev-cassandranodes-0
+cqlsh
+cqlsh> use lasair
+cqlsh> ALTER TABLE diaSources ADD "exposureTime"  float;
+etc etc as above
+exit
+----------------
+ssh lasair-lsst-dev-ingest-0
+cd lasair-lsst/pipeline/ingest/
+git fetch
+git switch schema_11_1
+python3 ingest.py --maxalert=100 --group_id=blabla12
+
+    INFO:ingest:2026-06-27T06:52:49Z 100 alerts 1348 diaSource 223 forcedSource 5 noObject
+
+--> same on ingest-1
+exit
+------------------
+--> back to bootstrap
+./start.sh ingest
+```

--- a/deploy/common/settings.py.j2
+++ b/deploy/common/settings.py.j2
@@ -35,7 +35,7 @@ PUBLIC_GROUP_ID        = 'test124'
 # Schema registry
 #################
 SCHEMA_REG_URL = "https://rubin-alert-schemas.slac.stanford.edu/schema-registry"
-SCHEMA_VERSION = "11_0"
+SCHEMA_VERSION = "11_1"
 
 # Pipeline runtime
 ##################


### PR DESCRIPTION
[Schema 11.1](https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema/11/1) evolution as documented [here](https://github.com/lsst-uk/lasair-lsst/tree/schema_11_1/common/schema#update-june-2026).

Because there are no modifications to the MySQL (only Cassandra) this is a simple change.

This branch has been used to ingest 11.0 alerts, thus showing that a minor schema update is backward compatible.

- Have any tests been written to test the new code in this pull request?
  - [x] No. I have added the reason for the lack of testing below. 
- Have you added any new documentation for the changes in this pull-request?
  - [x] Yes. I state below where the documentation lives.

