### PR TITLE
Making room for tags

### DIFF
--- a/common/schema/11_1/annotations.py
+++ b/common/schema/11_1/annotations.py
@@ -56,7 +56,7 @@ schema = {
   ],
   "indexes": [
     "PRIMARY KEY    (annotationID)",
-    "UNIQUE KEY     one_per_object (diaObjectId, topic)",
+    "UNIQUE KEY     one_per_object (diaObjectId, topic, classification)",
     "KEY topic_idx (topic)"
   ]
 }

--- a/pipeline/filter/annotation/annotationcore.py
+++ b/pipeline/filter/annotation/annotationcore.py
@@ -74,11 +74,16 @@ class AnnotationFilter(Filter):
             self.ann_diaObjectId[annotator] = [annotation['diaObjectId']]
 
         # put the annotation in the database
-        query = 'REPLACE INTO annotations ('
-        query += 'diaObjectId, topic, version, classification, explanation, classdict, url'
-        query += ') VALUES ('
-        query += "'%s', '%s', '%s', '%s', '%s', '%s', '%s')"
-        query = query % (
+        queryd = 'DELETE FROM annotations WHERE diaObjectId=%d AND topic="%s"'
+        queryd = queryd % (
+                annotation['diaObjectId'], 
+                annotation['topic'])
+
+        queryr = 'REPLACE INTO annotations ('
+        queryr += 'diaObjectId, topic, version, classification, explanation, classdict, url'
+        queryr += ') VALUES ('
+        queryr += "'%s', '%s', '%s', '%s', '%s', '%s', '%s')"
+        queryr = queryr % (
                 annotation['diaObjectId'], 
                 annotation['topic'], 
                 annotation['version'], 
@@ -88,7 +93,8 @@ class AnnotationFilter(Filter):
                 annotation['url'])
 
         if self.transfer:
-            self.execute_remote_query(query)
+            self.execute_remote_query(queryd)
+            self.execute_remote_query(queryr)
         return 1
 
     def post_ingest(self, n_messages):

--- a/pipeline/filter/annotation/annotationcore.py
+++ b/pipeline/filter/annotation/annotationcore.py
@@ -79,7 +79,7 @@ class AnnotationFilter(Filter):
                 annotation['diaObjectId'], 
                 annotation['topic'])
 
-        queryr = 'REPLACE INTO annotations ('
+        queryr = 'INSERT INTO annotations ('
         queryr += 'diaObjectId, topic, version, classification, explanation, classdict, url'
         queryr += ') VALUES ('
         queryr += "'%s', '%s', '%s', '%s', '%s', '%s', '%s')"

--- a/tests/unit/pipeline/filter/test_filtercore_annotator.py
+++ b/tests/unit/pipeline/filter/test_filtercore_annotator.py
@@ -55,7 +55,8 @@ class AnnotationFilterTest(unittest.TestCase):
         fltr.ann_diaObjectId = {}
         result = fltr.ingest_annotation(test_annotation)
         self.assertEqual(result, 1)
-        mock_execute_remote_query.assert_called_once()
+        # a delete and an insert
+        self.assertEqual(mock_execute_remote_query.call_count, 2)
 
     @patch('annotationcore.AnnotationFilter.ingest_annotation')
     @patch('annotationcore.AnnotationFilter.ingest_message_list')


### PR DESCRIPTION
This change modifies the annotator uniqueness to make room for tags.

-  It implies a change to the relational database:
ALTER TABLE annotations DROP INDEX one_per_object;
ALTER TABLE annotations ADD CONSTRAINT one_per_object UNIQUE (diaObjectId, topic, classification);

- A REPLACE query has become a DELETE then INSERT

- Schema 11_1 is changed to create the annotations table correctly

- Have any tests been written to test the new code in this pull request?
  - [x] Yes. I have modified the existing unit test, also run a few 100 annotations thru
- Have you added any new documentation for the changes in this pull-request?
  - [x] Documentation on database changes is above
  - [x] Plan for implementing tags is [here](https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/4957372417/Using+Annotations+for+Tags)
