### PR TITLE
Fix missing reference to cassandra_mapping.yaml for cutoutcass nodes

### DIFF
--- a/deploy/deploy.yaml
+++ b/deploy/deploy.yaml
@@ -268,6 +268,7 @@
   gather_facts: false
   vars_files:
     - settings.yaml
+    - cassandra_mapping.yaml
   vars:
     cassandra_cluster_name: "{{ group_names[0] }}"
     cassandra_commitlog_dir: /var/lib/cassandra-commitlog


### PR DESCRIPTION
Added casssandra_mapping.yaml to the cutoutcass deployment. (It's been there before. It must have got accidentally removed.)

Please remember to follow the Lasair Pull Request checklist when issuing & reviewing this pull request:

https://lsst-uk.atlassian.net/wiki/spaces/LUSC/pages/2612264961/How+to+do+Pull+Request#STEP-3%3A-Issue-a-Pull-Request-on-Github

# CHECKLIST

- Have any tests been written to test the new code in this pull request?
  - [ ] Yes. I have added the command to run the test below.
  - [X] No. I have added the reason for the lack of testing below. 
- Have you added any new documentation for the changes in this pull-request?
  - [ ] Yes. I state below where the documentation lives.
  - [X] No. No new documentation was needed.

This can only be tested properly when deploying a new cassandra cluster. The fix prevents errors from being thrown by the ansible playbook when doing incremental updates.