### PR TITLE
update to user.id

### DIFF
--- a/webserver/lasairapi/serializers.py
+++ b/webserver/lasairapi/serializers.py
@@ -316,7 +316,7 @@ class QuerySerializer(serializers.Serializer):
             offset = int(offset)
 
         try:
-            error = check_query(selected, tables, conditions, user=userId)
+            error = check_query(selected, tables, conditions, user=userId.id)
         except Exception as e:
             error = str(e)
 


### PR DESCRIPTION
This fixes a bug in the API code that decides if a watchlist/map is private or not. Really I'm not sure how `userId.id` (correct) got converted back to `userId` (incorrect). Anyway, this fixes it.


- Have any tests been written to test the new code in this pull request?
  -  No. I have added the reason for the lack of testing below. 
- Have you added any new documentation for the changes in this pull-request?
  -  No. No new documentation was needed.
