### PR TITLE
Fix/output

### DIFF
--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -157,6 +157,8 @@ def filter_query_detail(request, mq_id, action=False):
             filterQuery.topic_name = tn
             delete_stream_file(request, filterQuery.name)
             message = ''
+            if filterQuery.output is None
+                filterQuery.output = 0
             output = int(filterQuery.output)
             if output >= 2:
                 try:
@@ -191,11 +193,14 @@ def filter_query_detail(request, mq_id, action=False):
         newFil.date_expire = \
             datetime.datetime.now() + datetime.timedelta(days=settings.ACTIVE_EXPIRE)
         newFil.save()
+
+        message = ''
+        if newFil.output is None
+            newFil.output = 0
         filterQuery = newFil
         mq_id = filterQuery.pk
 
-        message = ''
-        output = int(newFil.output)
+        output = int(filterQuery.output)
         if output >= 2:
             try:
                 message += topic_refresh(newFil.real_sql, tn, output, limit=10) + '<br/>'
@@ -426,7 +431,11 @@ def filter_query_create(request, mq_id=False):
                 else:
                     filterQuery.run = 0
                 if request.POST.get('output'):
-                    filterQuery.output = int(request.POST.get('output'))
+                    filterQuery.output = request.POST.get('output')
+                    if filterQuery.output is None
+                        filterQuery.output = 0
+                    else:
+                        filterQuery.output = int(filterQuery.output)
                 else:
                     filterQuery.output = 0
 

--- a/webserver/lasair/apps/filter_query/views.py
+++ b/webserver/lasair/apps/filter_query/views.py
@@ -157,7 +157,7 @@ def filter_query_detail(request, mq_id, action=False):
             filterQuery.topic_name = tn
             delete_stream_file(request, filterQuery.name)
             message = ''
-            if filterQuery.output is None
+            if filterQuery.output is None:
                 filterQuery.output = 0
             output = int(filterQuery.output)
             if output >= 2:
@@ -195,7 +195,7 @@ def filter_query_detail(request, mq_id, action=False):
         newFil.save()
 
         message = ''
-        if newFil.output is None
+        if newFil.output is None:
             newFil.output = 0
         filterQuery = newFil
         mq_id = filterQuery.pk
@@ -432,7 +432,7 @@ def filter_query_create(request, mq_id=False):
                     filterQuery.run = 0
                 if request.POST.get('output'):
                     filterQuery.output = request.POST.get('output')
-                    if filterQuery.output is None
+                    if filterQuery.output is None:
                         filterQuery.output = 0
                     else:
                         filterQuery.output = int(filterQuery.output)


### PR DESCRIPTION
Discovered Internal Server Error when duplicating a filter. Its because the `filterQuery.output` is getting set to `None`. This PR catches those and makes sure they become zero instead.

- Have any tests been written to test the new code in this pull request?
  - [ ] Yes. I have added the command to run the test below.
  - [x] No. I have added the reason for the lack of testing below. 
- Have you added any new documentation for the changes in this pull-request?
  - [ ] Yes. I state below where the documentation lives.
  - [x] No. No new documentation was needed.

